### PR TITLE
handle SVGs with a viewBox but no width or height

### DIFF
--- a/vpype/read.py
+++ b/vpype/read.py
@@ -45,15 +45,17 @@ def read(file, quantization: float) -> LineCollection:
         # https://css-tricks.com/scale-svg/
         # TODO: we should honor the `preserveAspectRatio` attribute
 
-        w = convert(root.attrib["width"])
-        h = convert(root.attrib["height"])
+        viewbox_min_x, viewbox_min_y, viewbox_width, viewbox_height = [
+            float(s) for s in root.attrib["viewBox"].split()
+        ]
 
-        viewbox = [float(s) for s in root.attrib["viewBox"].split()]
+        w = convert(root.attrib.get("width", viewbox_width))
+        h = convert(root.attrib.get("height", viewbox_height))
 
-        scale_x = w / (viewbox[2] - viewbox[0])
-        scale_y = h / (viewbox[3] - viewbox[1])
-        offset_x = -viewbox[0]
-        offset_y = -viewbox[1]
+        scale_x = w / viewbox_width
+        scale_y = h / viewbox_height
+        offset_x = -viewbox_min_x
+        offset_y = -viewbox_min_y
     else:
         scale_x = 1
         scale_y = 1


### PR DESCRIPTION
First of all: `vpype` looks rad and I'm excited to play with it!

I ran `vpype read example.svg show --colorful` on an SVG with a `viewBox` but no `width` or `height` and got a `KeyError`. Here's the relevant part of the stack trace:

```
  File "/Users/benl/src/vpype/vpype/decorators.py", line 160, in generator
    state.vector_data.add(f(*args, **kwargs), target_layer)
  File "/Users/benl/src/vpype/vpype/read.py", line 48, in read
    w = convert(root.attrib["width"])
KeyError: 'width'
```

This PR fixes that error. It also looked like the width of the viewBox wasn't getting calculated correctly, so I changed that. All the tests still pass, and my test SVG looks like it's scaled/offset correctly.

Here's the raw SVG in question. I wasn't sure if it made sense to include it in the test data or not, but feel free!

```
<svg padding="2em" viewBox="750 -650 900 1300" xmlns="http://www.w3.org/2000/svg">
<path d="M826,-113 L1134,291" fill="none" stroke="black" stroke-width="5"/>
<path d="M851,-79 L1148,227" fill="none" stroke="black" stroke-width="5"/>
<path d="M877,-45 L1162,163" fill="none" stroke="black" stroke-width="5"/>
<path d="M903,-12 L1176,99" fill="none" stroke="black" stroke-width="5"/>
<path d="M928,21 L1190,35" fill="none" stroke="black" stroke-width="5"/>
<path d="M954,55 L1204,-29" fill="none" stroke="black" stroke-width="5"/>
<path d="M980,89 L1218,-93" fill="none" stroke="black" stroke-width="5"/>
<path d="M1005,122 L1232,-157" fill="none" stroke="black" stroke-width="5"/>
<path d="M1031,156 L1246,-221" fill="none" stroke="black" stroke-width="5"/>
<path d="M1057,190 L1260,-285" fill="none" stroke="black" stroke-width="5"/>
<path d="M1082,223 L1274,-349" fill="none" stroke="black" stroke-width="5"/>
<path d="M1108,257 L1288,-413" fill="none" stroke="black" stroke-width="5"/>
<path d="M1134,291 L1302,-477" fill="none" stroke="black" stroke-width="5"/>
</svg>
```