### PR TITLE
Add a `split all` command (addresses #19)

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -25,6 +25,7 @@ MINIMAL_COMMANDS = [
     "linesimplify",
     "multipass",
     "reloop",
+    "splitall"
 ]
 
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -352,3 +352,16 @@ def multipass(lines: LineCollection, count: int):
         )
 
     return new_lines
+
+
+@cli.command(group="Operations")
+@layer_processor
+def splitall(lines: LineCollection) -> LineCollection:
+    """
+    TODO doc
+    """
+
+    new_lines = LineCollection()
+    for line in lines:
+        new_lines.extend([line[i : i + 2] for i in range(len(line) - 1)])
+    return new_lines


### PR DESCRIPTION
To address #19, a `splitall` command is added to split existing paths in their constituent components.

cc @kcajf