### PR TITLE
Documentation edits

### DIFF
--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -57,7 +57,7 @@ The geometries passed from command to command are organised as a collection of l
 .. image:: images/layers.svg
    :width: 300px
 
-The primary purpose of layers in *vypype* is to create or process files for multicolored plots, where each layer contains geometries to be drawn with a specific pen or color. In *vpype*, layers are identified by a non-zero, positive integer (e.g. 1, 2,...). You can have as many layers as you want, memory permitting.
+The primary purpose of layers in *vpype* is to create or process files for multicolored plots, where each layer contains geometries to be drawn with a specific pen or color. In *vpype*, layers are identified by a non-zero, positive integer (e.g. 1, 2,...). You can have as many layers as you want, memory permitting.
 
 Each layer consists of an ordered collection of paths. In *vpype*, paths are so-called "polylines", meaning lines made of one or more straight segments. Each path is therefore described by a sequence of 2D points. Internally, these points are stored as complex numbers (this is invisible to the user but relevant to :ref:`plugin <plugins>` writers).
 

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -9,15 +9,15 @@ Fundamentals
 Pipeline
 ========
 
-Useful output is obtained from *vpype* by composing 'pipelines' of 'commands'. In a given pipeline, geometries are passed from command to command, starting with the first all the way to the last.
+To use *vpype*, you compose 'pipelines' of 'commands'. In a given pipeline, geometries are passed from command to command, starting with the first all the way to the last.
 
 .. image:: images/pipeline.svg
 
-Pipelines are created by passing *vpype* with the first command name together with its options and arguments, then the next command name, etc.::
+Pipelines are created by passing *vpype* the first command name together with its options and arguments, then the next command name, and so on.::
 
   $ vpype command1 [--option X [...]] [ARG [...]] command2 [--option X [...]] [ARG [...]] ...
 
-The list of every commands is available in from the CLI::
+The list of every command is available by running the help option on the core vpype comamnd::
 
   $ vpype --help
   Usage: vpype [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
@@ -29,20 +29,9 @@ The list of every commands is available in from the CLI::
                         current directory.
     -s, --seed INTEGER  Specify the RNG seed.
     --help              Show this message and exit.
-
-  Commands:
-
-    Primitives:
-      circle        Generate lines approximating a circle.
-      line          Generate a single line.
-      rect          Generate a rectangle.
-
-    Operations:
-      crop          Crop the geometries.
-      linemerge     Merge lines whose endings overlap or are very close.
       ...
 
-Help on each command is also available on the CLI, for example::
+Help on each command is also available by running the help option on that command, for example::
 
   $ vpype circle --help
   Usage: vpype circle [OPTIONS] X Y R
@@ -63,18 +52,18 @@ Help on each command is also available on the CLI, for example::
 Lines and layers
 ================
 
-The geometries passed from command to command is organised as a collection of layers, each containing a collection of paths.
+The geometries passed from command to command are organised as a collection of layers, each containing a collection of paths.
 
 .. image:: images/layers.svg
    :width: 300px
 
-The primary purpose of layers is to create or process files for multi-color plots, where each layer contains geometries to be drawn with the specific pen or color. In *vpype*, layers are identified by a non-zero, positive integer (e.g. 1, 2,...). There can be an arbitrary number of layers, memory permitting.
+The primary purpose of layers in *vypype* is to create or process files for multicolored plots, where each layer contains geometries to be drawn with a specific pen or color. In *vpype*, layers are identified by a non-zero, positive integer (e.g. 1, 2,...). You can have as many layers as you want, memory permitting.
 
-Each layer consists of an ordered collection of paths. In *vpype*, paths are so-called polylines, or lines made of one or more straight segments. Each path is thus described by a sequence of 2D points. Internally, these points are stored as complex numbers (this is invisible to the user but relevant to :ref:`plugin <plugins>` writers).
+Each layer consists of an ordered collection of paths. In *vpype*, paths are so-called "polylines", meaning lines made of one or more straight segments. Each path is therefore described by a sequence of 2D points. Internally, these points are stored as complex numbers (this is invisible to the user but relevant to :ref:`plugin <plugins>` writers).
 
-Curved paths are not supported *per se*. Instead, everything is linearised into small segments that are small enough to approximate curvature in a way that is invisible in the final plot. For example, the :program:`read` command transforms all curved SVG elements (such as circle or bezier paths) into paths made of segment, using a maximum segment size that may be set by the user (so-called quantization). This design choice makes *vpype* very flexible and easy to develop, with no practical impact on final plot quality, but is the primary reason why *vpype* is not fit to be (and is not meant as) a general-purpose vector data processing tool.
+Curved paths are not supported *per se*. Instead, curves are converted into linear segments that are small enough to approximate curvature in a way that is invisible in the final plot. For example, the :program:`read` command transforms all curved SVG elements (such as circles or bezier paths) into paths made of segments, using a maximum segment size that can be set by the user (so-called "quantization"). This design choice makes *vpype* very flexible and easy to develop, with no practical impact on final plot quality, but is the primary reason why *vpype* is not fit to be (and is not meant as) a general-purpose vector data processing tool.
 
-One down-side of using polylines to approximate curved element is the potential increase of output file size. For example, three numbers are sufficient to describe a circle, but 10 to 100 segments may be needed to approximate it sufficiently well for plotting. When this becomes an issue, tuning the quantization parameters and using the :program:`linesimplify` command can help.
+One downside of using polylines to approximate curved element is a potential increase in output file size. For example, three numbers are sufficient to describe a circle, but 10 to 100 segments may be needed to approximate it sufficiently well for plotting. When this becomes an issue, tuning the quantization parameters with the ``-q`` option or using the :program:`linesimplify` command can help.
 
 
 .. _fundamentals_commands:
@@ -82,7 +71,7 @@ One down-side of using polylines to approximate curved element is the potential 
 Command taxonomy
 ================
 
-Commands come in 3 different types: *generators*, *layer processors* and *global processors*. Although it is not strictly necessary to use *vpype*, understanding the difference between them help to have a good grasp on how it works, and is very useful if you plan on writing your own :ref:`plug-ins <plugins>`.
+Commands come in three different types: *generators*, *layer processors* and *global processors*. Although it is not strictly necessary to understand the difference between them to use *vpype*, it helps to have a good grasp on how they work, and is very useful if you plan on writing your own :ref:`plug-ins <plugins>`.
 
 .. image:: images/command_types.svg
    :width: 600px
@@ -93,15 +82,18 @@ Commands come in 3 different types: *generators*, *layer processors* and *global
 Generators
 ----------
 
-Generators add new geometries to a target layer, ignoring (but preserving) any content in this layer. Other layers' content is not affected by a generator. They accept a ``--layer TARGET`` option to control which layer should receive the new geometries. By default, the target layer of the previous generator command is used, or layer 1 if the generator is the first. Here is an example::
+Generators add new geometries to a target layer, ignoring (but preserving) any content already existing in the layer. Other layers' content is not affected. They accept a ``--layer TARGET`` option to control which layer should receive the new geometries. By default, the target layer of the previous generator command is used, or layer 1 if the generator is the first. Here's an example::
 
-  $ vpype line --layer 3 0 0 1cm 1cm circle 0.5cm 0.5cm 0.5cm
+  $ vpype line --layer 3 0 0 1cm 1cm circle 0.5cm 0.5cm 0.3cm
 
-Both :program:`line` and :program:`circle` are generator commands which both create the type of paths you would expect. In this case, both the circle and the line end up in layer 3. For generators, ``--layer new`` can also be used to generate geometries in the empty layer with the lowest possible identifier.
+This command will first draw a :program:`line` on layer 3 from the point (0,0) a point at (1cm, 1cm), then it will draw a :program:`circle` also on layer 3 (defaulting to the target of the previous command) centred on the point (0.5cm, 0.5cm), with a radius of 0.3cm.
 
-Here are a few more example of generators (the list is not exhaustive):
+For generators, ``--layer new`` can be used to generate geometries in a new, empty layer with the lowest possible number identifier.
+
+A few more examples of generators include:
 
 * :program:`rect`: generates a rectangle
+* :program:`arc`: generates lines approximating a circular arc
 * :program:`frame`: generates a single-line frame around the existing geometries
 
 
@@ -110,21 +102,21 @@ Here are a few more example of generators (the list is not exhaustive):
 Layer processors
 ----------------
 
-Contrary to generators, layer processors generally do not produce new paths but instead modify existing geometries. Further, they do so on a layer by layer basis. This means that the way a layer processor modifies one layer's content bears no consequences on how it will affect another layer. Let's consider for example :program:`linemerge`. This command looks for paths whose either endings are close to each other (according to some tolerance) and merges them when they are, avoiding costly pen-up/pen-down operations by the plotter. Since :program:`linemerge` is a layer processor, it will only merge paths within the same layer.
+Unlike generators, layer processors generally don't produce new paths but instead modify existing ones on a layer-by-layer basis. This means that the way a layer processor changes one layer's content has no bearing on how it will affect another layer. Let's consider for example :program:`linemerge`. This command looks for paths whose ends are close to one another (according to some tolerance) and merges them to avoid unnecessary pen-up/pen-down operations by the plotter. Since :program:`linemerge` is a layer processor, it will only merge paths within the same layer.
 
-Layer processors accept a ``--layer TARGET[,TARGET[,...]]`` option to specify one or more layer on which they should be applies. Here are some examples::
+Layer processors accept a ``--layer TARGET[,TARGET[,...]]`` option to specify one or more layer on which they should be applied. Here are some examples::
 
   $ vpype [...] crop --layer 1      0 0 10cm 10cm
   $ vpype [...] crop --layer 1,2,4  0 0 10cm 10cm
   $ vpype [...] crop --layer all    0 0 10cm 10cm
 
-All these commands do exactly what you think they should do. If the ``--layer`` option is omitted, then ``all`` is assumed and layer processors will process every single (existing) layer. Note that if you provide a list of layers, they must be comma separated and without any whitespace.
+All these commands crop the specified layers to a 10cm x 10cm rectangle with a top-left corner at (0,0). If the ``--layer`` option is omitted, then ``all`` is assumed and the layer process will target every single (existing) layer. Note that if you provide a list of layers, they must be comma separated without any whitespace.
 
-Here are a few examples of layer processors (the list is non-exhaustive):
+A few more examples of layer processors include:
 
-* :program:`translate`: apply a translation on the geometries
-* :program:`linesort`: sort paths within the layer such as to minimize the distance travelled by the plotter in pen-up position
-* :program:`linesimplify`: reduce the number of points in paths which ensuring a specified precision, in order to minimize output file size
+* :program:`translate`: apply a translation to the geometries (i.e. move them)
+* :program:`linesort`: sort paths within the layer in such a way that the distance travelled by the plotter in pen-up position is minimized
+* :program:`linesimplify`: reduce the number of points in paths while ensuring a specified precision, in order to minimize output file size
 
 
 .. _fundamentals_global_processors:
@@ -132,24 +124,24 @@ Here are a few examples of layer processors (the list is non-exhaustive):
 Global processors
 -----------------
 
-While layer processors are executed multiple times, once for each layer they are applied on, global processors are executed only once and apply globally to all layers. Depending on the command,they may or may not have layer-related parameters, although there is no rule about.
+While layer processors are executed multiple times, once for each layer they are targeted to, global processors are executed only once and apply to all layers. Depending on the command, they may or may not have layer-related parameters, although there is no rule about that.
 
-For example, the :program:`write` command uses all layers in the pipeline to generate a multi-layer SVG file. Because they use the geometry center as reference (by default), the :program:`rotate`, :program:`scale`, and :program:`skew` transformation commands are also implemented as global processors, although they accept a `--layer` option which behaves much like layer processors.
+For example, the :program:`write` command uses all layers in the pipeline to generate a multi-layer SVG file. The :program:`rotate`, :program:`scale`, and :program:`skew` transformation commands are also implemented as global processors because they use the center of the geometry as reference (by default), although they also accept a `--layer` option which makes them behave much like a layer processor.
 
 .. _fundamentals_units:
 
 Units
 =====
 
-Like the SVG format, the default unit use by *vpype* is the CSS pixel, which is defined as 1/96th of an inch. For example, the following command will generate a 1-inch-radius circle centered on coordinates (0, 0)::
+Like the SVG format, the default unit used by *vpype* is the CSS pixel, which is defined as 1/96th of an inch. For example, the following command will generate a 1-inch-radius circle centered on coordinates (0, 0)::
 
   $ vpype circle 0 0 96
 
-Because the pixel is not the best unit to deal with physical supports, most commands understand other CSS units including ``in``, ``cm``, ``mm``, ``pt`` and ``pc``. The 1-inch-radius circle can thus equivalently be generated like this::
+Because the pixel is not the best unit to use with physical media, most commands understand other CSS units including ``in``, ``cm``, ``mm``, ``pt`` and ``pc``. The 1-inch-radius circle can therefore also be generated like this::
 
   $ vpype circle 0 0 1in
 
-Note that there must be no whitespace between the number and the unit, otherwise they would be considered as distinct CLI arguments.
+Note that there must be no whitespace between the number and the unit, otherwise they would be considered as different command-line arguments.
 
 Internally, units other than CSS pixels are converted as soon as possible and pixels are used everywhere in the code (see :class:`Length`).
 
@@ -164,7 +156,7 @@ Blocks
 
 Blocks refer to a portion of the pipeline marked by the :program:`begin` and :program:`end` special commands. The command immediately following :program:`begin` is called the *block processor* and controls how many times the block pipeline is executed and what is done with the geometries it produced.
 
-The most commonly used block processor is the :program:`grid` command. It repeatedly execute the block pipeline and arrange the result on a regular NxM grid. For example, this command generates a grid of five by ten 1-inch-diameter circles, spaced every 2 inches in both directions::
+A commonly used block processor is the :program:`grid` command. It repeatedly executes the commands inside the block (known as the "block pipeline") and arranges the results on a regular grid. For example, this command generates a grid of five by ten 0.5-inch-radius circles, with a spacing of two inches in both directions::
 
   $ vpype begin                     \
         grid --offset 2in 2in 5 10  \
@@ -172,14 +164,14 @@ The most commonly used block processor is the :program:`grid` command. It repeat
       end                           \
       show
 
-Note: we use backslash to escape the end-of-line in order to highlight the nested structure of blocks and how it emerges as some kind of mini-language.
+Note: The backslashes allow you to escape the end-of-line and split a command across multiple lines. In this case, it highlights the nested structure of blocks and how it emerges as some kind of mini-language.
 
 Here is the result:
 
 .. image:: images/circle_grid.png
    :width: 400px
 
-Let us break down what happened here. The :program:`begin` and :program:`end` define a block whose processor in the :program:`grid` command. The block pipeline consists of a single :program:`circle` command, which generates a 1-inch-diameter circle centered on 0, 0. This pipeline is executed 50 times (for a 5x10 grid), and their result is translated by the :program:`grid` command by offsets of 2 inches. After the block, the :program:`show` commands displays the result.
+Let's break down what's happening here. The :program:`begin` and :program:`end` define a block whose processor is the :program:`grid` command. The block pipeline consists of a single :program:`circle` command, which generates a 0.5-inch-radius circle centered on 0, 0. The pipeline is executed 50 times (once for every location in a 5x10 grid), and the result is translated (i.e. moved) two inches each time by the :program:`grid` command. After the block, the :program:`show` commands displays the result.
 
 Blocks can be nested to achieve more complex compositions. Here is an example::
 
@@ -199,7 +191,7 @@ And the result:
 .. image:: images/random_grid.png
    :width: 400px
 
-When using blocks, it is important to understand that a block pipeline is always executed from a blank state, even if geometries existed in before the block. The block pipeline's result is added to the global (or parent) pipeline only at the end of the block. Consider the following for example (the :program:`ldelete` command deletes the layer passed in argument)::
+When using blocks, it is important to understand that a block pipeline is always executed from a blank state, even if geometries exist before the block begins. The block pipeline's result is added to the global (or parent) pipeline only at the end of the block. To understand this, consider the following example (the :program:`ldelete` command deletes the layer passed in argument)::
 
   $ vpype                           \
       circle --layer 1 0 0 1cm      \
@@ -210,25 +202,20 @@ When using blocks, it is important to understand that a block pipeline is always
       end                           \
       show
 
-Before the block, a 1cm-radius circle is added to layer 1. Then, the block pipeline starts by deleting the layer 1 before adding a 0.5cm-radius circle.
-
-Here is the result:
+Before the block, a 1cm-radius circle is added to layer 1. Then, the block pipeline starts by initializing a 3x3 grid - for each space in the grid it deletes layer 1 before adding a 0.5cm-radius circle. However, since the block pipeline is executed from a blank state, the :program:`ldelete` command has nothing to remove and all 10 circle (nine from the grid block on layer 10, plus the original on layer one) are visible in the output:
 
 .. image:: images/ldelete_grid.png
    :width: 400px
-
-Since the block pipeline is executed from a blank state, the :program:`ldelete` command has no effect and all 10 circles are visible in the output.
-
 
 .. _fundamentals_command_files:
 
 Command files
 =============
 
-Pipelines be quite complex, especially when using blocks, which can become cumbersome in the command-line. To address this, all or parts of a pipeline can be stored in so-called command files which *vpype* can then refer to. A command file is a text file whose content is interpreted as if it was command-line arguments. Newlines and indentation are ignored and useful only for readability. Everything to the right of a ``#`` character is considered
+Pipelines be quite complex, especially when using blocks, which can become cumbersome to include in the command-line. To address this, all or parts of a pipeline of commands can be stored in so-called "command files" which *vpype* can then refer to. A command file is a text file whose content is interpreted as if it was command-line arguments. Newlines and indentation are ignored and useful only for readability. Everything to the right of a ``#`` character is considered
 a comment and is ignored.
 
-The nested block example of the previous section can be converted to a command file with the following content::
+The nested block example from the previous section could be converted to a command file with the following content::
 
   # command_file.vpy - example command file
   begin
@@ -242,15 +229,15 @@ The nested block example of the previous section can be converted to a command f
   end
   show
 
-The command file can then be loaded as argument using the `-I` or `--include` option::
+The command file can then be loaded as an argument using the `-I` or `--include` option::
 
   $ vpype -I command_file.vpy
 
-Regular arguments and command files can be mixed arbitrarily::
+Regular arguments and command files can be mixed in any combination::
 
   $ vpype -I generate_lines.vpy write -p a4 -c output.svg
 
-Finally, command files can also include other command files::
+Finally, command files can also reference other command files::
 
   # Example command file
   begin

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ In a nutshell, *vpype* is an extensible CLI pipeline utility which aims to be th
 
     ``vpype read input.svg scale 2 2 linesort write output.svg``
 
-  Here the geometries are loaded from a file (``read input.svg``), their size is doubled in both directions (``scale 2 2``), paths are reordered to minimize plotting time (``linesort``), and a SVG file is created with the result (``write output.svg``).
-- Extensible: new commands can easily be added to *vpype* through plug-ins. This allows third parties to extend *vpype* with new commands and yourself to write your own generative algorithm in the form of *vpype* plug-ins.
+  Here the geometries are loaded from a file (``read input.svg``), their size is doubled in both directions (``scale 2 2``), paths are reordered to minimize plotting time (``linesort``), and an SVG file is created with the result (``write output.svg``).
+- Extensible: new commands can easily be added to *vpype* with plug-ins. This allows anyone to extend *vpype* with new commands or to write their own generative algorithm.
 - Plotter vector graphics: *vpype* focuses on the niche of vector graphics for plotters (such as the `Axidraw <https://www.axidraw.com>`_) rather than being a general purpose vector processing utility.
 - Swiss Army knife: *vpype* is flexible, contains many tools and its author is Swiss.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Using this documentation
 
 Start with `installation instructions <install>`_ to get up and running with your installation of *vpype*.
 
-Fro the straight-to-action type, the list of available commands is available in the `reference <reference>`_ section. You may also jump to the `cookbook <cookbook>`_ section to find a recipe that matches your need.
+For the straight-to-action type, the list of available commands is available in the `reference <reference>`_ section. You may also jump to the `cookbook <cookbook>`_ section to find a recipe that matches your need.
 
 For a deep understanding of *vpype*, take a dive in the section on `fundamentals <fundamentals>`_.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,41 +5,12 @@ Installation
 This page explain how to install *vpype* for end-users. If you intend to develop on *vpype*, refer to the the :ref:`contributing` section.
 
 
-Linux
-=====
-
-.. highlight:: bash
-
-*vpype* requires Python 3.6 or later. On Debian/ubuntu flavored installation, installing Python is a matter of::
-
-  $ sudo apt-get install python3 python3-pip
-
-The preferred way to install *vpype* is in a dedicated `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_. Follow these steps to do so::
-
-  $ python3 -m venv vpype_venv      # create a new virtual environment
-  $ source vpype_venv/bin/activate  # activate the newly created virtual environment
-  $ pip install --upgrade pip
-  $ pip install git+https://github.com/abey79/vpype.git#egg=vpype
-
-You should now be able to run *vpype*::
-
-  $ vpype --help
-
-Each time a new terminal window is opened, the virtual environment must be activated using::
-
-  $ source vpype_venv/bin/activate
-
-Alternatively, *vpype* can be executed using the full path to the executable::
-
-  $ /path/to/vpype_venv/bin/vpype --help
-
-
 macOS
 =====
 
 .. highlight:: bash
 
-While macOS ships with a version of Python, this has been deprecated by Apple and may change in future versions. Instead, you should install Python (preferably 3.8, minimum 3.6), either from `MacPorts <https://www.macports.org>`_ or from `Homebrew <https://brew.sh>`_.
+While macOS ships with a version of Python, this has been deprecated by Apple and may change in future version. Instead, you should install Python (preferably 3.8, minimum 3.6), either from `MacPorts <https://www.macports.org>`_ or from `Homebrew <https://brew.sh>`_.
 
 Use the following commands for Homebrew::
 
@@ -67,20 +38,6 @@ Each time a new terminal window is opened, the virtual environment must be activ
 Alternatively, *vpype* can be executed using the full path to the executable::
 
   $ /path/to/vpype_venv/bin/vpype --help
-
-
-Raspberry Pi
-============
-
-.. highlight:: bash
-
-Installing *vpype* on Raspbian is similar to Linux, but a number of libraries must be installed beforehand::
-
-  $ sudo apt-get install git python3-shapely python3-dev
-
-Also, the following command must be added to the ``~/.bashrc`` file for *vpype* to execute correctly::
-
-  export LD_PRELOAD=/usr/lib/arm-linux-gnueabihf/libatomic.so.1
 
 
 Windows
@@ -148,3 +105,46 @@ This command should open a window showing a circle::
   > vpype circle 0 0 10cm show
 
 If you can see it, your installation is up and running!
+
+
+Linux
+=====
+
+.. highlight:: bash
+
+*vpype* requires Python 3.6 or later. On Debian/ubuntu flavored installation, installing Python is a matter of::
+
+  $ sudo apt-get install python3 python3-pip
+
+The preferred way to install *vpype* is in a dedicated `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_. Follow these steps to do so::
+
+  $ python3 -m venv vpype_venv      # create a new virtual environment
+  $ source vpype_venv/bin/activate  # activate the newly created virtual environment
+  $ pip install --upgrade pip
+  $ pip install git+https://github.com/abey79/vpype.git#egg=vpype
+
+You should now be able to run *vpype*::
+
+  $ vpype --help
+
+Each time a new terminal window is opened, the virtual environment must be activated using::
+
+  $ source vpype_venv/bin/activate
+
+Alternatively, *vpype* can be executed using the full path to the executable::
+
+  $ /path/to/vpype_venv/bin/vpype --help
+
+
+Raspberry Pi
+============
+
+.. highlight:: bash
+
+Installing *vpype* on Raspbian is similar to Linux, but a number of libraries must be installed beforehand::
+
+  $ sudo apt-get install git python3-shapely python3-dev
+
+Also, the following command must be added to the ``~/.bashrc`` file for *vpype* to execute correctly::
+
+  export LD_PRELOAD=/usr/lib/arm-linux-gnueabihf/libatomic.so.1

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,7 +39,7 @@ macOS
 
 .. highlight:: bash
 
-While macOS ships with a version of Python, this has been deprecated by Apple and may change in future version. It is recommended to install Python (preferably 3.8, minimum 3.6) either from `MacPorts <https://www.macports.org>`_ or from `Homebrew <https://brew.sh>`_.
+While macOS ships with a version of Python, this has been deprecated by Apple and may change in future versions. Instead, you should install Python (preferably 3.8, minimum 3.6), either from `MacPorts <https://www.macports.org>`_ or from `Homebrew <https://brew.sh>`_.
 
 Use the following commands for Homebrew::
 


### PR DESCRIPTION
I've reworked the index, install and fundamentals documentation.

- In `index.rst` I've fixed a couple of small typos and improved the clarity of a line.
- In `install.rst` I've re-ordered the OS list so Mac and Windows are at the top, on the grounds that most people will be using those platforms, and that Linux/RPi users are less likely to need help. Also made a small clarity tweak.
- In `fundamentals.rst` I've done a substantive line edit, fixing typos and improving the clarity and communication where possible. Structure is unchanged.