### PR TITLE
Let shlex handle comments

### DIFF
--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -257,11 +257,7 @@ def extract_arguments(f: TextIO) -> List[str]:
     """
     args = []
     for line in f.readlines():
-        idx = line.find("#")
-        if idx != -1:
-            line = line[:idx]
-
-        args.extend(shlex.split(line))
+        args.extend(shlex.split(line, comments=True))
     return args
 
 


### PR DESCRIPTION
The way comment handling was previously done, the hash character (`#`) could never be used in a string passed as an argument when parsed from a file included with the `-I` flag. This is because the hash character and the text that followed it were being explicitly excluded without checking whether the hash character occurred in quotes.

Luckily `shlex` has this kind of checking built in. When `shlex` does the comment handling (with the `comments` argument on the `split` method set to `True`), hash characters outside of quotes are considered comment delimiters and are appropriately ignored along with any text that follows, as normal. Crucially, however, hash characters *that are in quotes* are not considered delimiters and are not ignored.

This became an issue when trying to use `vpype-text` with an included command file that included commands whose arguments contained text that included the hash character, (e.g., `text "text #1"`).

This PR fixes the above issue.