### PR TITLE
Edit --page-format documentation

### DIFF
--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -90,7 +90,8 @@ Examples:
     default="tight",
     help=(
         "Set the bounds of the SVG to a specific page format. If omitted, the SVG size it set "
-        "to the geometry bounding box."
+        "to the geometry bounding box. "
+        f"Default page formats are: {', '.join(PAGE_FORMATS.keys())}"
     ),
 )
 @click.option(


### PR DESCRIPTION
I found the list of formats accepted by `--page-format` to be in an unintuitive place. Now it's included in the description in the list of options.