### PR TITLE
Add support for angle units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 New features and improvements:
 * Added `snap` command (#110)
 * Invisible SVG elements are now discarded (#103)
+* Add support for angle units (affects `rotate`, `skew`, and `arc` commands, `--radian` option is removed) (#111)
 
 API changes:
-* Added vpype_cli.execute() to execute a vpype pipeline from python (#104)
+* Added `vpype_cli.execute()` to execute a vpype pipeline from Python (#104)
+* Added `vpype.convert_angle()` and `vpype.AngleType` (#111)
 
 Bug fixes:
 * Fixed `write` to cap SVG width and height to a minimum of 1px (#102)

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -146,7 +146,14 @@ Because the pixel is not the best unit to use with physical media, most commands
 
 Note that there must be no whitespace between the number and the unit, otherwise they would be considered as different command-line arguments.
 
-Internally, units other than CSS pixels are converted as soon as possible and pixels are used everywhere in the code (see :class:`Length`).
+Internally, units other than CSS pixels are converted as soon as possible and pixels are used everywhere in the code (see :class:`LengthType`).
+
+Likewise, angles are interpreted as degrees by default but alternative units may be specified, including ``deg``, ``rad``, ``grad`` and ``turn``. The following examples all rotate a rectangle by 45 degrees::
+
+  $ vpype rect 0 0 50 100 rotate 45
+  $ vpype rect 0 0 50 100 rotate 50grad
+  $ vpype rect 0 0 50 100 rotate 0.125turn
+  $ vpype rect 0 0 50 100 rotate 0.785398rad
 
 
 .. _fundamentals_blocks:

--- a/vpype/model.py
+++ b/vpype/model.py
@@ -216,11 +216,46 @@ class LineCollection:
             line.imag *= sy
 
     def rotate(self, angle: float) -> None:
+        """Rotates the geometry by ``angle`` amount.
+
+        The angle is expressed in radian. Positive value rotate clockwise.
+
+        The rotation is performed about the coordinates origin (0, 0). To rotate around a
+        specific location, appropriate translations must be performed before and after the
+        scaling::
+
+            >>> import vpype
+            >>> lc = vpype.LineCollection([(-1+1j, 1+1j)])
+            >>> lc.translate(0, -1)
+            >>> lc.rotate(1.2)
+            >>> lc.translate(0, 1)
+
+        Args:
+            angle: rotation angle in rad
+        """
         c = complex(math.cos(angle), math.sin(angle))
         for line in self._lines:
             line *= c
 
     def skew(self, ax: float, ay: float) -> None:
+        """Skew the geometry by some angular amounts along X and Y axes.
+
+        The angle is expressed in radians.
+
+        The skew is performed about the coordinates origin (0, 0). To rotate around a
+        specific location, appropriate translations must be performed before and after the
+        scaling::
+
+            >>> import vpype
+            >>> lc = vpype.LineCollection([(-1+1j, 1+1j)])
+            >>> lc.translate(0, -1)
+            >>> lc.skew(0., 1.2)
+            >>> lc.translate(0, 1)
+
+        Args:
+            ax: skew angle in rad along X axis
+            ay: skew angle in rad along Y axis
+        """
         tx, ty = math.tan(ax), math.tan(ay)
         for line in self._lines:
             line += tx * line.imag + 1j * ty * line.real

--- a/vpype/utils.py
+++ b/vpype/utils.py
@@ -90,7 +90,7 @@ def convert_length(value: Union[str, float]) -> float:
     return _convert_unit(value, UNITS)
 
 
-def convert(value: Union[str, float]) -> float:
+def convert(value: Union[str, float]) -> float:  # pragma: no cover
     """Deprecated, use convert_length."""
     logging.warning(
         "!!! `vpype.convert()` is deprecated, use `vpype.convert_length()` instead."
@@ -163,7 +163,7 @@ def convert_page_size(value: str) -> Tuple[float, float]:
     return float(x) * convert_length(x_unit), float(y) * convert_length(y_unit)
 
 
-def convert_page_format(value: str) -> Tuple[float, float]:
+def convert_page_format(value: str) -> Tuple[float, float]:  # pragma: no cover
     """Deprecated, use convert_page_size."""
     logging.warning(
         "!!! `vpype.convert_page_format()` is deprecated, use `vpype.convert_page_size()` "
@@ -199,7 +199,7 @@ class LengthType(click.ParamType):
             self.fail(f"parameter {value} is an incorrect length")
 
 
-class Length(LengthType):
+class Length(LengthType):  # pragma: no cover
     """Deprecated, use LengthType."""
 
     def __init__(self, *args, **kwargs):

--- a/vpype_cli/primitives.py
+++ b/vpype_cli/primitives.py
@@ -78,8 +78,8 @@ def rect(
 @click.argument("y", type=vp.LengthType())
 @click.argument("rw", type=vp.LengthType())
 @click.argument("rh", type=vp.LengthType())
-@click.argument("start", type=vp.LengthType())
-@click.argument("stop", type=vp.LengthType())
+@click.argument("start", type=vp.AngleType())
+@click.argument("stop", type=vp.AngleType())
 @click.option(
     "-q",
     "--quantization",
@@ -94,8 +94,11 @@ def arc(
     """Generate lines approximating a circular arc.
 
     The arc is centered on (X, Y) and has a radius of R and spans counter-clockwise from START
-    to STOP angles (in degrees). Angular values of zero refer to east of unit circle and
-    positive values extend counter-clockwise.
+    to STOP angles. Angular values of zero refer to east of unit circle and positive values
+    extend counter-clockwise.
+
+    Angles are in degree by default, but alternative CSS units such as "rad" or "grad" may be
+    provided.
     """
     return vp.LineCollection([vp.arc(x, y, rw, rh, start, stop, quantization)])
 


### PR DESCRIPTION
#### Description

* Angle units may be: `deg`, `rad`, `grad`, `turn`
* `arc` accepts angle units
* `rotate` & `skew` accept angle units and have `--radian` option removed
* Added `convert_angle()` and `AngleType` API

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
