### PR TITLE
Add `reverse` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 New features and improvements:
 * A Windows installer is now available (#120)
+* Added `reverse` command (#129)
 
 Bug fixes:
 * Fixed crash for SVG with <desc> element (#127)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ and much more.
 - Closed paths' **seam location randomization**, to reduce the visibility of pen-up/pen-down artifacts ([`reloop`](https://vpype.readthedocs.io/en/stable/reference.html#reloop)).
 - Support for generating **multiple passes** on each line ([`multipass`](https://vpype.readthedocs.io/en/stable/reference.html#multipass)).
 - Support for **filtering** by line lengths or closed-ness ([`filter`](https://vpype.readthedocs.io/en/stable/reference.html#filter)).
+- Support for **reversing** order of paths within their layers ([`reverse`](https://vpype.readthedocs.io/en/stable/reference.html#reverse)).
  
  #### Generation
  

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 
 import numpy as np
 import pytest
@@ -47,6 +46,7 @@ MINIMAL_COMMANDS = [
     "pagesize 10inx15in",
     "stat",
     "snap 1",
+    "reverse",
 ]
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -133,6 +133,14 @@ def test_line_collection_pen_up_trajectories():
     assert line_collection_contains(pen_up, [25j, 3 + 3j])
 
 
+def test_line_collection_reverse():
+    line_arr = [(0, 100j, 1000, 10), (5j, 3, 25j), (3 + 3j, 100, 10j)]
+    lc = LineCollection(line_arr)
+    lc.reverse()
+    for i, line in enumerate(reversed(line_arr)):
+        assert np.all(lc[i] == np.array(line))
+
+
 def test_document_lid_iteration():
     lc = LineCollection([(0, 1 + 1j)])
     doc = Document()

--- a/vpype/model.py
+++ b/vpype/model.py
@@ -158,6 +158,10 @@ class LineCollection:
         """
         return len(self) == 0
 
+    def reverse(self) -> None:
+        """Reverse order of the lines."""
+        self._lines = list(reversed(self._lines))
+
     def __iter__(self):
         return self._lines.__iter__()
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -379,7 +379,12 @@ def snap(line_collection: vp.LineCollection, pitch: float) -> vp.LineCollection:
 @cli.command(group="Operations")
 @vp.layer_processor
 def reverse(line_collection: vp.LineCollection) -> vp.LineCollection:
-    """Reverse order of lines."""
+    """Reverse order of lines.
+
+    Reverse the order of lines within their respective layers. Individual lines are not
+    modified (in particular, their trajectory is not inverted). Only the order in which they
+    are drawn is reversed.
+    """
 
     line_collection.reverse()
     return line_collection

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -374,3 +374,12 @@ def snap(line_collection: vp.LineCollection, pitch: float) -> vp.LineCollection:
 
     new_lines.scale(pitch)
     return new_lines
+
+
+@cli.command(group="Operations")
+@vp.layer_processor
+def reverse(line_collection: vp.LineCollection) -> vp.LineCollection:
+    """Reverse order of lines."""
+
+    line_collection.reverse()
+    return line_collection


### PR DESCRIPTION
#### Description

New `reverse` command to reverse the order of paths within a layer.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
