### PR TITLE
splitall now filter out segments where both points are identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ New features and improvements:
 * Minor loading time improvement (#133)
 * Added large format paper sizes (A2, A1, A0) (#144)
 
+Bug fixes:
+* `splitall` filter out segments where both points are identical (#70)
+
 
 #### 1.2.1 (2020-12-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 New features and improvements:
 * Minor loading time improvement (#133)
 * Added large format paper sizes (A2, A1, A0) (#144)
-
-Bug fixes:
-* `splitall` filter out segments where both points are identical (#70)
+* The `splitall` command will now filter out segments with identical end-points (#146)
 
 
 #### 1.2.1 (2020-12-26)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -365,3 +365,16 @@ def test_snap_no_duplicate(pitch: float):
         assert np.all(lc[0][:-1] != lc[0][1:])
     else:
         assert len(lc) == 0
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ([0, 1 + 2j, 2], [[0, 1 + 2j], [1 + 2j, 2]]),
+        ([0, 1 + 2j, 1 + 2j, 2], [[0, 1 + 2j], [1 + 2j, 2]]),
+    ],
+)
+def test_splitall_filter_duplicates(line, expected):
+    lc = execute_single_line("splitall", line)
+
+    assert np.all(l == el for l, el in zip(lc, expected))

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -241,7 +241,8 @@ def splitall(lines: vp.LineCollection) -> vp.LineCollection:
     Split all paths into their constituent segments.
 
     This command may be used together with `linemerge` for cases such as densely-connected
-    meshes where the latter cannot optimize well enough by itself.
+    meshes where the latter cannot optimize well enough by itself. Using this command will
+    filter out segments where both points are identical.
 
     Note that since some paths (especially curved ones) can be made of a large number of
     segments, this command may significantly increase the processing time of the pipeline.

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -241,8 +241,8 @@ def splitall(lines: vp.LineCollection) -> vp.LineCollection:
     Split all paths into their constituent segments.
 
     This command may be used together with `linemerge` for cases such as densely-connected
-    meshes where the latter cannot optimize well enough by itself. Using this command will
-    filter out segments where both points are identical.
+    meshes where the latter cannot optimize well enough by itself. This command will
+    filter out segments with identical end-points.
 
     Note that since some paths (especially curved ones) can be made of a large number of
     segments, this command may significantly increase the processing time of the pipeline.

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -249,7 +249,9 @@ def splitall(lines: vp.LineCollection) -> vp.LineCollection:
 
     new_lines = vp.LineCollection()
     for line in lines:
-        new_lines.extend([line[i : i + 2] for i in range(len(line) - 1)])
+        new_lines.extend(
+            [line[i : i + 2] for i in range(len(line) - 1) if line[i] != line[i + 1]]
+        )
     return new_lines
 
 


### PR DESCRIPTION
#### Description

Fix issue #70 

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
