### PR TITLE
Add `layout` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 #### 1.3 (UNRELEASED)
 
 New features and improvements:
+* Added new `layout` command (#168)
+  
+  This command automates the page layout process on a specified the page size by centering the geometries (with
+  customizable horizontal and vertical alignment) and optionally fitting to specified margins. It intends to supersede
+  `write`'s layout options (i.e. `--page-size` and `--center`) in more intuitive way. In particular, since this command
+  acts on the pipeline rather than on the output file, its effect can be previewed with the `show` command.
+
 * (Beta) Complete rewrite of the viewer underlying the `show` command (#163)
   * fully hardware-accelerated rendering engine
   * smooth zooming and panning, with touchpad and mouse support
@@ -13,9 +20,13 @@ New features and improvements:
   * interactively adjustable display settings
     
   **Note**: This new viewer is a beta feature and will evolve in future versions. Your feedback is welcome. The current, matplotlib-based viewer is still available using `show --classic`.
+
 * Added large format paper sizes (A2, A1, A0) (#144)
 * The `splitall` command will now filter out segments with identical end-points (#146)
 * Minor loading time improvement (#133)
+
+Bug fixes:
+* Fixed the `linemerge` command's help string (#170, thanks to @theomega)
 
 API changes:
 * The new viewer engine and Qt-based GUI has a documented API and is available for use by third-party packages (#163).

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ and much more.
 
 #### Layout and transforms
 
+- Easy and flexible **layout** command for centring and fitting to margin with selectable le horizontal and vertical alignment
+  ([`layout`](https://vpype.readthedocs.io/en/stable/reference.html#layout)).
 - Powerful **transform** commands for scaling, translating, skewing and rotating geometries ([`scale`](https://vpype.readthedocs.io/en/stable/reference.html#scale), [`translate`](https://vpype.readthedocs.io/en/stable/reference.html#translate), [`skew`](https://vpype.readthedocs.io/en/stable/reference.html#skew), [`rotate`](https://vpype.readthedocs.io/en/stable/reference.html#rotate)).
 - Support for **scaling** and **cropping** to arbitrary dimensions ([`scaleto`](https://vpype.readthedocs.io/en/stable/reference.html#scaleto), [`crop`](https://vpype.readthedocs.io/en/stable/reference.html#crop)).
 - Support for **trimming** geometries by an arbitrary amount ([`trim`](https://vpype.readthedocs.io/en/stable/reference.html#trim)).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 # -- Project information -----------------------------------------------------
+# noinspection PyPackageRequirements
+from recommonmark.parser import CommonMarkParser
 
 project = "vpype"
 # noinspection PyShadowingBuiltins
@@ -33,7 +35,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_click.ext",
     "sphinx_autodoc_typehints",
-    "recommonmark",
+    # "recommonmark", # NOTE: see workaround below
     # "alabaster",
     # 'autoapi.extension',
 ]
@@ -86,6 +88,7 @@ intersphinx_mapping = {
 
 napoleon_include_init_with_doc = True
 
+
 # noinspection PyUnusedLocal
 def autodoc_skip_member(app, what, name, obj, skip, options):
     exclusions = (
@@ -108,5 +111,18 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
     return skip or exclude
 
 
+# RECOMMONMARK WORKAROUND
+# see https://github.com/readthedocs/recommonmark/issues/177
+
+
+class CustomCommonMarkParser(CommonMarkParser):
+    def visit_document(self, node):
+        pass
+
+
 def setup(app):
     app.connect("autodoc-skip-member", autodoc_skip_member)
+
+    # recommonmark workaround
+    app.add_source_suffix(".md", "markdown")
+    app.add_source_parser(CustomCommonMarkParser)

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -11,31 +11,41 @@ Cookbook
 Laying out a SVG for plotting
 =============================
 
-This command will :ref:`cmd_read` an SVG file, and then :ref:`cmd_write` it to a new SVG file sized to A4 portrait::
+There are two ways to layout geometries on a page. The preferred way is to use commands such as :ref:`cmd_layout`, :ref:`cmd_scale`, :ref:`cmd_scaleto`, :ref:`cmd_translate`. In particular, :ref:`cmd_layout` handles most common cases
+by centering the geometries on page and optionally scaling them to fit specified margins. These commands act on the pipeline and their effect can be previewed using the :ref:`cmd_show` command. The following examples all use this approach.
 
-  $ vpype read input.svg write --page-size a4 output.svg
+Alternatively, the :ref:`cmd_write` commands offers option such as :option:`--page-size <write --page-size>` and
+:option:`--center <write --center>` which can also be used to layout geometries. It must be understood that these
+options *only* affect the output file and leave the pipeline untouched. Their effect cannot be previewed by the
+:ref:`cmd_show` command, even if it placed after the :ref:`cmd_write` command.
 
-This command will :ref:`cmd_read` an SVG file, and then :ref:`cmd_write` it to a new SVG file sized to 13x9in, rotated to landscape, with the design centred on the page::
 
-  $ vpype read input.svg write --page-size 13x9in --landscape --center output.svg
+This command will :ref:`cmd_read` a SVG file, and then :ref:`cmd_write` it to a new SVG file sized to A4 in landscape orientation, with the design centred on the page::
 
-This command will :ref:`cmd_read` a multilayered SVG file, flatten it by converting all layers to a single layer, and then :ref:`cmd_write` it to a new SVG with the boundaries fitted tightly around the design::
+  $ vpype read input.svg layout --landscape a4 write output.svg
 
-  $ vpype read --single-layer input.svg write output.svg
+The :ref:`cmd_layout` command implicitly centers the geometries on the page. The :ref:`cmd_pagesize` command can be used
+to choose the page size without changing the geometries::
 
-This command will :ref:`cmd_read` an SVG file, :ref:`cmd_scale` it down to a 80% of its original size, and then :ref:`cmd_write` it to a new A5-sized SVG, centred on the page::
+  $ vpype read input.svg pagesize --landscape a4 write output.svg
 
-  $ vpype read input.svg scale 0.8 0.8 write output.svg
+This command will :ref:`cmd_read` a SVG file and lay it out to 3cm margin with a top vertical alignment (a generally pleasing arrangement for square designs on the portrait-oriented page), and then :ref:`cmd_write` it to a new SVG::
 
-This command will :ref:`cmd_read` an SVG file, scale it down to a 5x5cm square (using the :ref:`cmd_scaleto` command), and then :ref:`cmd_write` it to a new A5-sized SVG, centred on the page::
+  $ vpype read input.svg layout --fit-to-margin 3cm --valign top a4 write output.svg
 
-  $ vpype read input.svg scaleto 5cm 5cm write --page-size a5 --center output.svg
+This command will :ref:`cmd_read` a SVG file, :ref:`cmd_scale` it down to a 80% of its original size, and then :ref:`cmd_write` it to a new A5-sized SVG, centred on the page::
 
-This command will :ref:`cmd_read` an SVG file, :ref:`cmd_crop` it to a 10x10cm square positioned 57mm from the top and left corners of the design, and then :ref:`cmd_write` it to a new SVG::
+  $ vpype read input.svg scale 0.8 0.8 layout a5 write output.svg
+
+This command will :ref:`cmd_read` a SVG file, scale it down to a 5x5cm square (using the :ref:`cmd_scaleto` command), and then :ref:`cmd_write` it to a new A5-sized SVG, centred on the page::
+
+  $ vpype read input.svg scaleto 5cm 5cm layout a5 write output.svg
+
+This command will :ref:`cmd_read` a SVG file, :ref:`cmd_crop` it to a 10x10cm square positioned 57mm from the top and left corners of the design, and then :ref:`cmd_write` it to a new SVG whose page size will be identical to the input SVG::
 
   $ vpype read input.svg crop 57mm 57mm 10cm 10cm write output.svg
 
-This command will :ref:`cmd_read` an SVG file, add a single-line :ref:`cmd_frame` around the design, 5cm beyond its bounding box, and then :ref:`cmd_write` it to a new SVG::
+This command will :ref:`cmd_read` a SVG file, add a single-line :ref:`cmd_frame` around the design, 5cm beyond its bounding box, and then :ref:`cmd_write` it to a new SVG::
 
   $ vpype read input.svg frame --offset 5cm write output.svg
 
@@ -57,7 +67,7 @@ Note that :option:`write --pen-up` should only be used for previsualization purp
 Optimizing a SVG for plotting
 =============================
 
-This command will :ref:`cmd_read` an SVG file, merge any lines whose endings are less than 0.5mm from each other with :ref:`cmd_linemerge`, and then :ref:`cmd_write` a new SVG file::
+This command will :ref:`cmd_read` a SVG file, merge any lines whose endings are less than 0.5mm from each other with :ref:`cmd_linemerge`, and then :ref:`cmd_write` a new SVG file::
 
   $ vpype read input.svg linemerge --tolerance 0.5mm write output.svg
 
@@ -65,19 +75,19 @@ In some cases such as densely connected meshes (e.g. a grid where made of touchi
 
   $ vpype read input.svg splitall linemerge --tolerance 0.5mm write output.svg
 
-This command will :ref:`cmd_read` an SVG file, simplify its geometry by reducing the number of segments in a line until they're a maximum of 0.1mm from each other using :ref:`cmd_linesimplify`, and then :ref:`cmd_write` a new SVG file::
+This command will :ref:`cmd_read` a SVG file, simplify its geometry by reducing the number of segments in a line until they're a maximum of 0.1mm from each other using :ref:`cmd_linesimplify`, and then :ref:`cmd_write` a new SVG file::
 
   $ vpype read input.svg linesimplify --tolerance 0.1mm write output.svg
 
-This command will :ref:`cmd_read` an SVG file, randomise the seam location for paths whose beginning and end points are a maximum of 0.03mm from each other with :ref:`cmd_reloop`, and then :ref:`cmd_write` a new SVG file::
+This command will :ref:`cmd_read` a SVG file, randomise the seam location for paths whose beginning and end points are a maximum of 0.03mm from each other with :ref:`cmd_reloop`, and then :ref:`cmd_write` a new SVG file::
 
   $ vpype read input.svg reloop --tolerance 0.03mm write output.svg
 
-This command will :ref:`cmd_read` an SVG file, extend each line with a mirrored copy of itself three times using :ref:`cmd_multipass`, and then :ref:`cmd_write` a new SVG file. This is useful for pens that need a few passes to get a good result::
+This command will :ref:`cmd_read` a SVG file, extend each line with a mirrored copy of itself three times using :ref:`cmd_multipass`, and then :ref:`cmd_write` a new SVG file. This is useful for pens that need a few passes to get a good result::
 
   $ vpype read input.svg multipass --count 3 write output.svg
 
-This command will :ref:`cmd_read` an SVG file, use :ref:`cmd_linesort` to sort the lines to minimise pen-up travel distance, and then :ref:`cmd_write` a new SVG file::
+This command will :ref:`cmd_read` a SVG file, use :ref:`cmd_linesort` to sort the lines to minimise pen-up travel distance, and then :ref:`cmd_write` a new SVG file::
 
   $ vpype read input.svg linesort write output.svg
 
@@ -125,7 +135,7 @@ to the :ref:`cmd_write` command::
 
   $ vpype read input.svg write --device hp7475a output.hpgl
 
-The plotter paper size will be inferred from the current page size (which is set by the input SVG in this case).
+The plotter paper size will be inferred from the current page size (as set by the input SVG or using either the :ref:`cmd_pagesize` or :ref:`cmd_layout` commands).
 The plotter type/paper format combination must exist in the built-in or user-provided configuration file. See
 :ref:`faq_custom_hpgl_config` for information on how to create one. If a matching plotter paper size cannot be found,
 an error will be generated. In this case, the paper size must manually specified with the :option:`--page-size <write --page-size>` option::
@@ -138,7 +148,7 @@ for SVG output, the :option:`--center <write --center>` is often use to center t
 It is typically useful to optimize the input SVG during the conversion. The following example is typical of real-world
 use::
 
-  $ vpype read input.svg linesimplify reloop linemerge linesort write --device hp7475a --page-size a4 output.hpgl
+  $ vpype read input.svg linesimplify reloop linemerge linesort layout a4 write --device hp7475a output.hpgl
 
 
 Defining a default HPGL plotter device

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -47,6 +47,10 @@ CLI reference
 .. click:: vpype_cli:GridBlockProcessor
    :prog: grid
 
+.. _cmd_layout:
+.. click:: vpype_cli:layout
+   :prog: layout
+
 .. _cmd_lcopy:
 .. click:: vpype_cli:lcopy
    :prog: lcopy

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "cachetools"
-version = "4.2.0"
+version = "4.2.1"
 description = "Extensible memoizing collections and decorators"
 category = "main"
 optional = false
@@ -912,8 +912,8 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 cachetools = [
-    {file = "cachetools-4.2.0-py3-none-any.whl", hash = "sha256:c6b07a6ded8c78bf36730b3dc452dfff7d95f2a12a2fed856b1a0cb13ca78c61"},
-    {file = "cachetools-4.2.0.tar.gz", hash = "sha256:3796e1de094f0eaca982441c92ce96c68c89cced4cd97721ab297ea4b16db90e"},
+    {file = "cachetools-4.2.1-py3-none-any.whl", hash = "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2"},
+    {file = "cachetools-4.2.1.tar.gz", hash = "sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,6 +47,7 @@ MINIMAL_COMMANDS = [
     "stat",
     "snap 1",
     "reverse",
+    "layout a4",
 ]
 
 
@@ -70,7 +71,7 @@ def test_commands_execute(args):
 @pytest.mark.parametrize("args", MINIMAL_COMMANDS)
 def test_commands_keeps_page_size(runner, args):
     """No command shall "forget" the current page size, unless its `pagesize` of course."""
-    if args.split()[0] == "pagesize":
+    if args.split()[0] in ["pagesize", "layout"]:
         return
 
     page_size = None
@@ -378,3 +379,31 @@ def test_splitall_filter_duplicates(line, expected):
     lc = execute_single_line("splitall", line)
 
     assert np.all(l == el for l, el in zip(lc, expected))
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_bounds"),
+    [
+        ("10x10cm", (4.5, 4.5, 5.5, 5.5)),
+        ("-h left -v top a4", (0, 0, 1, 1)),
+        ("-m 3cm -h left -v top 10x20cm", (3, 3, 7, 7)),
+        ("-m 3cm -v bottom 10x20cm", (3, 13, 7, 17)),
+        ("-m 3cm -h right 20x10cm", (13, 3, 17, 7)),
+        ("-m 3cm -h right -l 20x10cm", (13, 3, 17, 7)),
+    ],
+)
+def test_layout(runner, args, expected_bounds):
+    document = vp.Document()
+
+    @cli.command()
+    @vp.global_processor
+    def sample(doc: vp.Document):
+        nonlocal document
+        document = doc
+
+    res = runner.invoke(cli, f"random -n 100 rect 0 0 1cm 1cm layout {args} sample")
+    assert res.exit_code == 0
+    bounds = document.bounds()
+    assert bounds is not None
+    for act, exp in zip(bounds, expected_bounds):
+        assert act == pytest.approx(exp * CM)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -58,6 +58,18 @@ def test_commands_empty_geometry(runner, args):
 
 
 @pytest.mark.parametrize("args", MINIMAL_COMMANDS)
+def test_commands_single_line(runner, args):
+    result = runner.invoke(cli, "line 0 0 10 10 " + args)
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("args", MINIMAL_COMMANDS)
+def test_commands_degenerate_line(runner, args):
+    result = runner.invoke(cli, "line 0 0 0 0 " + args)
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("args", MINIMAL_COMMANDS)
 def test_commands_random_input(runner, args):
     result = runner.invoke(cli, "random -n 100 " + args)
     assert result.exit_code == 0
@@ -390,6 +402,7 @@ def test_splitall_filter_duplicates(line, expected):
         ("-m 3cm -v bottom 10x20cm", (3, 13, 7, 17)),
         ("-m 3cm -h right 20x10cm", (13, 3, 17, 7)),
         ("-m 3cm -h right -l 20x10cm", (13, 3, 17, 7)),
+        ("-m 3cm -h right -l 10x20cm", (13, 3, 17, 7)),
     ],
 )
 def test_layout(runner, args, expected_bounds):

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -382,6 +382,21 @@ def layout(
     align: str,
     valign: str,
 ) -> vp.Document:
+    """Layout the geometries on the provided page size.
+
+    By default, this command centers everything on the page. The horizontal and vertical
+    alignment can be adjusted using the `--align`, resp. `--valign` options.
+
+    Optionally, this command can scale the geometries to fit specified margins with the
+    `--fit-to-margin` option.
+
+    Examples:
+
+        Fit the geometries to 3cm margins with top alignment (a generally pleasing arrangement
+        for square designs on portrait-oriented pages):
+
+            vpype read input.svg layout --fit-to-margin 3cm --valign top a4 write.svg
+    """
 
     if landscape and size[0] < size[1]:
         size = size[::-1]

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 import click
 import numpy as np
@@ -11,6 +11,7 @@ from .cli import cli
 __all__ = (
     "crop",
     "filter_command",
+    "layout",
     "linemerge",
     "linesimplify",
     "linesort",
@@ -313,10 +314,9 @@ def filter_command(
     return lines
 
 
-# noinspection PyShadowingNames
 @cli.command(group="Operations")
 @click.argument("size", type=vp.PageSizeType(), required=True)
-@click.option("-l", "--landscape", is_flag=True, default=False, help="Target layer(s).")
+@click.option("-l", "--landscape", is_flag=True, default=False, help="Landscape orientation.")
 @vp.global_processor
 def pagesize(document: vp.Document, size, landscape) -> vp.Document:
     """Change the current page size.
@@ -344,7 +344,83 @@ def pagesize(document: vp.Document, size, landscape) -> vp.Document:
             vpype [...] pagesize 11inx15in [...]
     """
 
-    document.page_size = size[::-1] if landscape else size
+    document.page_size = size[::-1] if landscape and size[0] < size[1] else size
+    return document
+
+
+# noinspection PyShadowingNames
+@cli.command(group="Operations")
+@click.argument("size", type=vp.PageSizeType(), required=True)
+@click.option("-l", "--landscape", is_flag=True, default=False, help="Landscape orientation.")
+@click.option(
+    "-m",
+    "--fit-to-margins",
+    "margin",
+    type=vp.LengthType(),
+    help="Fit the geometries to page size with the specified margin.",
+)
+@click.option(
+    "-h",
+    "--align",
+    type=click.Choice(["left", "center", "right"]),
+    default="center",
+    help="Horizontal alignment",
+)
+@click.option(
+    "-v",
+    "--valign",
+    type=click.Choice(["top", "center", "bottom"]),
+    default="center",
+    help="Vertical alignment",
+)
+@vp.global_processor
+def layout(
+    document: vp.Document,
+    size: Tuple[float, float],
+    landscape: bool,
+    margin: Optional[float],
+    align: str,
+    valign: str,
+) -> vp.Document:
+
+    if landscape and size[0] < size[1]:
+        size = size[::-1]
+
+    document.page_size = size
+    bounds = document.bounds()
+
+    if bounds is None:
+        # nothing to layout
+        return document
+
+    min_x, min_y, max_x, max_y = bounds
+    width = max_x - min_x
+    height = max_y - min_y
+    if margin is not None:
+        document.translate(-min_x, -min_y)
+        scale = min((size[0] - 2 * margin) / width, (size[1] - 2 * margin) / height)
+        document.scale(scale)
+        min_x = min_y = 0.0
+        width *= scale
+        height *= scale
+    else:
+        margin = 0.0
+
+    if align == "left":
+        h_offset = margin - min_x
+    elif align == "right":
+        h_offset = size[0] - margin - width - min_x
+    else:
+        h_offset = margin + (size[0] - width - 2 * margin) / 2 - min_x
+
+    if valign == "top":
+        v_offset = margin - min_y
+    elif valign == "bottom":
+        v_offset = size[1] - margin - height - min_y
+    else:
+        v_offset = margin + (size[1] - height - 2 * margin) / 2 - min_y
+
+    document.translate(h_offset, v_offset)
     return document
 
 

--- a/vpype_cli/transforms.py
+++ b/vpype_cli/transforms.py
@@ -159,7 +159,13 @@ def scaleto(
     except ValueError:
         return document
 
-    factors = (dim[0] / (bounds[2] - bounds[0]), dim[1] / (bounds[3] - bounds[1]))
+    width = bounds[2] - bounds[0]
+    height = bounds[3] - bounds[1]
+
+    if width == 0.0 or height == 0.0:
+        return document
+
+    factors = dim[0] / width, dim[1] / height
     if not fit_dimensions:
         factors = (min(factors), min(factors))
 

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -288,7 +288,7 @@ class QtViewer(QWidget):
         self._mouse_coord_lbl.setFont(font)
         self._toolbar.addWidget(self._mouse_coord_lbl)
         # noinspection PyUnresolvedReferences
-        self._viewer_widget.mouse_coords.connect(self.set_mouse_coords)
+        self._viewer_widget.mouse_coords.connect(self.set_mouse_coords)  # type: ignore
 
         # setup layout
         layout = QVBoxLayout()


### PR DESCRIPTION
#### Description

The new `layout` command replaces the functionality of `write`'s `--page-size` and `--center` while making it compatible with other commands (in particular `show`) and adding new features.

**Old way**:

```
vpype read input.svg [...] write --center --landscape --page-size a3 output.svg show
```
Here `show` doesn't see the effect of `--center --page-size`, which is confusing.

**New way**:

```
vpype read input.svg [...] layout --landscape a3 write output.svg show
```
Since `layout` affects the pipeline, both `write` and `show` are affected, as one would expect. Also, centring is implicit.


**Additional features**:
- `--fit-to-margin 2cm`: scales everything to fit the specified page format with a given margin
- `--align left|center|right` and `--valign top|center|bottom` to control horizontal and vertical alignment (default to center)


Fixes #154 

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
