### PR TITLE
Correct linemerge documentation

### DIFF
--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -100,11 +100,12 @@ def trim(
 @vp.layer_processor
 def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
     """
-    Merge lines whose endings overlap or are very close.
+    Merge lines whose endings and starts overlap or are very close.
 
-    Stroke direction is preserved by default, so `linemerge` looks at joining a line's end with
-    another line's start. With the `--flip` stroke direction will be reversed as required to
-    further the merge.
+    By default, `linemerge` considers both directions of a stroke. If there is no additional
+    start of a stroke within the provided tolerance, it also checks for ending points of
+    strokes and uses them in reverse. You can use the `--no_flip` to disable this reversing
+    behaviour and preserve the stroke direction from the input.
 
     By default, gaps of maximum 0.05mm are considered for merging. This can be controlled with
     the `--tolerance` option.

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -104,7 +104,7 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
 
     By default, `linemerge` considers both directions of a stroke. If there is no additional
     start of a stroke within the provided tolerance, it also checks for ending points of
-    strokes and uses them in reverse. You can use the `--no_flip` to disable this reversing
+    strokes and uses them in reverse. You can use the `--no-flip` to disable this reversing
     behaviour and preserve the stroke direction from the input.
 
     By default, gaps of maximum 0.05mm are considered for merging. This can be controlled with


### PR DESCRIPTION
#### Description
The linemerge documention/help mentions a `--flip` command line option which is not present. Actually `--flip` is the default (now?) according to the code. I updated the documentation to explain the current behaviour.


#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
