### PR TITLE
Fix issues link in contributing documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ New features and improvements:
 * Minor loading time improvement (#133)
 
 Bug fixes:
-* Fixed the `linemerge` command's help string (#170, thanks to @theomega)
+* Various documentation fixes (#170, #172, thanks to @theomega)
 
 API changes:
 * The new viewer engine and Qt-based GUI has a documented API and is available for use by third-party packages (#163).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,7 +17,7 @@ Contributions are most welcome and there  are many ways you can help regardless 
 * Improve existing features or contribute entirely new ones with a `pull request`_. If you plan on creating new commands, consider making a :ref:`plugin <plugins>` first — it will be easy to integrate it into *vpype*'s codebase later on if it makes sense.
 
 
-.. _issue: https://github.com/abey79/vpype/issue
+.. _issue: https://github.com/abey79/vpype/issues
 
 .. _pull request: https://github.com/abey79/vpype/pulls
 


### PR DESCRIPTION
#### Description

The link to the issues was wrong in the documentation.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
