### PR TITLE
Correctly return the document after `show`

### DIFF
--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import pytest
 
+import vpype as vp
 import vpype_viewer
 from vpype_cli import cli
 

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -67,3 +67,19 @@ def test_show(assert_image_similarity, runner, monkeypatch, commands, params):
 
     assert res.exit_code == 0
     assert_image_similarity(image)
+
+
+def test_show_must_return_document(runner, monkeypatch):
+    @cli.command()
+    @vp.global_processor
+    def assertdoc(document):
+        assert document is not None
+        assert type(document) is vp.Document
+
+    def new_show(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(vpype_viewer, "show", new_show)
+
+    result = runner.invoke(cli, "line 0 0 10 10 show assertdoc")
+    assert result.exit_code == 0

--- a/vpype_cli/show.py
+++ b/vpype_cli/show.py
@@ -106,6 +106,7 @@ def show(
 
     return document
 
+
 def _test_mgl() -> bool:
     """Tests availability of ModernGL."""
     # noinspection PyBroadException

--- a/vpype_cli/show.py
+++ b/vpype_cli/show.py
@@ -104,6 +104,7 @@ def show(
             document, view_mode=view_mode, show_pen_up=show_pen_up, show_points=show_points
         )
 
+    return document
 
 def _test_mgl() -> bool:
     """Tests availability of ModernGL."""
@@ -249,5 +250,3 @@ def _show_mpl(
     if show_grid:
         plt.grid("on")
     plt.show()
-
-    return document


### PR DESCRIPTION


#### Description

Fixes #176 by returning the document when the actual function is called.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
