### PR TITLE
Viewer: make "Fit to window" persistent when resizing the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 #### 1.4 (UNRELEASED)
 
 New features and improvements:
-* Optimized the viewer upon launch and display setting changes (#184)
+* Viewer improvements:
+  * At start and when using the fit to window button, the display will now remain fitted to the window upon resizing,
+    until manual zooming or panning (#191)
+  * Optimized the viewer upon launch and display setting changes (#184)
 
 Bug fixes:
 * Documentation fixes (#186, thanks to @f4nu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features and improvements:
 * Python 3.9.1 (or later) is finally supported and is now the recommended version (#115)
 * Viewer improvements:
   * At start and when using the fit to window button, the display will now remain fitted to the window upon resizing,
-    until manual zooming or panning (#191)
+    until manual zooming or panning (#193)
   * Optimized the viewer upon launch and display setting changes (#184)
 
 Bug fixes:

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -67,9 +67,6 @@ class QtViewerWidget(QGLWidget):
             view_mode=ViewMode.OUTLINE, show_pen_up=False, render_cb=self.update
         )
 
-        # adjust default scale based on hidpi
-        self.engine.scale = self.window().devicePixelRatio()
-
     def document(self) -> Optional[vp.Document]:
         """Return the :class:`vpype.Document` currently assigned to the widget."""
         return self._document


### PR DESCRIPTION
#### Description

When the corresponding button is clicked or at start, the viewer fits the page size (or the geometry bounds) to the available space in the viewer window. With this change, this behaviour is maintained when the window is resized, until manual panning or zooming is done.

This also fixes a Divided by zero warning in some circumstances by clamping widget width/height to 1.

Fixes #191 

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
