### PR TITLE
Optimize viewer build process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New features and improvements:
 * Viewer improvements:
   * At start and when using the fit to window button, the display will now remain fitted to the window upon resizing,
     until manual zooming or panning (#193)
-  * Optimized the viewer upon launch and display setting changes (#184, #195)
+  * Significantly optimized launch and setting changes times (#184, #195)
 
 Bug fixes:
 * Various documentation fixes and improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New features and improvements:
 * Viewer improvements:
   * At start and when using the fit to window button, the display will now remain fitted to the window upon resizing,
     until manual zooming or panning (#193)
-  * Optimized the viewer upon launch and display setting changes (#184)
+  * Optimized the viewer upon launch and display setting changes (#184, #195)
 
 Bug fixes:
 * Various documentation fixes and improvements:

--- a/vpype_viewer/shaders/fast_line_vertex.glsl
+++ b/vpype_viewer/shaders/fast_line_vertex.glsl
@@ -1,14 +1,18 @@
 #version 330
 
 uniform mat4 projection;
+uniform vec4 colors[7];
 
 in vec2 in_vert;
-in vec4 in_color;
+in int color_idx;
 
 flat out vec4 v_color;
 
 void main() {
-    v_color = in_color;
+    v_color = colors[color_idx];
+    if ((gl_VertexID % 2) == 0)
+        v_color.rgb *= 0.6;
+
     gl_PointSize = 5.0;
     gl_Position = projection * vec4(in_vert, 0.0, 1.0);
 }


### PR DESCRIPTION
#### Description

For document containing many lines, switching display mode can be noticeably slow. This PR improves on a couple of elements:
- preview mode: use the simpler, single color version of the shader (smaller/faster buffer)
- point render: suppress useless index buffer object
- preview mode (colourful): massive optimisation of the buffer building code, changed color to color_idx in buffer

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
