### PR TITLE
API: rename CONFIG_MANAGER to config_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New features and improvements:
   * Added rulers with dynamic scale to the display (can be optionally hidden) (#199)
   * Added metric and imperial unit system (in addition to pixels), used by the rulers and the mouse coordinate display (#199)
   * Adjusted the size of the mouse coordinates text on Windows (#199)
+  
+API changes:
+  * Renamed `vpype.CONFIG_MANAGER` in favour of `vpype.config_manager` (existing name kept for compatibility) (#XXX)
 
 #### 1.4 (2021-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features and improvements:
   * Adjusted the size of the mouse coordinates text on Windows (#199)
   
 API changes:
-  * Renamed `vpype.CONFIG_MANAGER` in favour of `vpype.config_manager` (existing name kept for compatibility) (#XXX)
+  * Renamed `vpype.CONFIG_MANAGER` in favour of `vpype.config_manager` (existing name kept for compatibility) (#202)
 
 #### 1.4 (2021-02-08)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,8 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
         "convert",
         "convert_page_format",
         "Length",
+        # vpype/config.py
+        "CONFIG_MANAGER",
         # vpype_cli/debug.py
         "DebugData",
         # private attribute

--- a/tests/test_hpgl.py
+++ b/tests/test_hpgl.py
@@ -254,8 +254,8 @@ def test_hpgl_info_quiet(runner, simple_printer_config):
     ],
 )
 def test_hpgl_paper_config_from_size(simple_printer_config, paper_format, expected_name):
-    vp.CONFIG_MANAGER.load_config_file(simple_printer_config)
-    pc = vp.CONFIG_MANAGER.get_plotter_config("simple").paper_config_from_size(paper_format)
+    vp.config_manager.load_config_file(simple_printer_config)
+    pc = vp.config_manager.get_plotter_config("simple").paper_config_from_size(paper_format)
     if expected_name is None:
         assert pc is None
     else:
@@ -263,9 +263,9 @@ def test_hpgl_paper_config_from_size(simple_printer_config, paper_format, expect
 
 
 def test_hpgl_paper_config(simple_printer_config):
-    vp.CONFIG_MANAGER.load_config_file(simple_printer_config)
-    assert vp.CONFIG_MANAGER.get_plotter_config("simple").paper_config("simple") is not None
-    assert vp.CONFIG_MANAGER.get_plotter_config("simple").paper_config("DOESNTEXIST") is None
+    vp.config_manager.load_config_file(simple_printer_config)
+    assert vp.config_manager.get_plotter_config("simple").paper_config("simple") is not None
+    assert vp.config_manager.get_plotter_config("simple").paper_config("DOESNTEXIST") is None
 
 
 def test_hpgl_paper_size_inference(runner):
@@ -288,7 +288,7 @@ def test_hpgl_paper_size_inference_fail(runner):
 def test_hpgl_flex_no_pagesize(simple_printer_config):
     doc = vp.Document()
     doc.add(vp.LineCollection([(1 + 1j, 2 + 4j)]))
-    vp.CONFIG_MANAGER.load_config_file(simple_printer_config)
+    vp.config_manager.load_config_file(simple_printer_config)
     with pytest.raises(ValueError):
         vp.write_hpgl(
             output=sys.stdout,
@@ -305,7 +305,7 @@ def test_hpgl_wrong_ref(simple_printer_config):
     doc = vp.Document()
     doc.add(vp.LineCollection([(1 + 1j, 2 + 4j)]))
     doc.page_size = 10, 15
-    vp.CONFIG_MANAGER.load_config_file(simple_printer_config)
+    vp.config_manager.load_config_file(simple_printer_config)
     with pytest.raises(ValueError):
         vp.write_hpgl(
             output=sys.stdout,

--- a/vpype/config.py
+++ b/vpype/config.py
@@ -1,13 +1,13 @@
 """Config file support for vpype.
 
-Configuration data is accessed via the ``CONFIG_MANAGER`` global variable::
+Configuration data is accessed via the ``config_manager`` global variable::
 
-    >>> from vpype import CONFIG_MANAGER
-    >>> CONFIG_MANAGER.config  # dictionary of all configuration
+    >>> from vpype import config_manager
+    >>> config_manager.config  # dictionary of all configuration
 
 HPGL plotter have specific config support::
 
-    >>> plotter_config = CONFIG_MANAGER.get_plotter_config("hp7475a")
+    >>> plotter_config = config_manager.get_plotter_config("hp7475a")
     >>> plotter_config
     PlotterConfig(name='hp7475a', ...)
     >>> plotter_config.paper_config("a4")
@@ -29,6 +29,7 @@ __all__ = [
     "PaperConfig",
     "PlotterConfig",
     "ConfigManager",
+    "config_manager",
     "CONFIG_MANAGER",
 ]
 
@@ -152,10 +153,10 @@ class PlotterConfig:
 class ConfigManager:
     """Helper class to handle vpype's TOML configuration files.
 
-    This class is typically used via its singleton instance ``CONFIG_MANAGER``::
+    This class is typically used via its singleton instance ``config_manager``::
 
-        >>> from vpype import CONFIG_MANAGER
-        >>> my_config = CONFIG_MANAGER.config.get("my_config", None)
+        >>> from vpype import config_manager
+        >>> my_config = config_manager.config.get("my_config", None)
 
     Helper methods are provided for specific aspects of configuration, such as command-specific
     configs or HPGL-related configs.
@@ -237,14 +238,17 @@ class ConfigManager:
         return self._config
 
 
-CONFIG_MANAGER = ConfigManager()
+config_manager = ConfigManager()
+
+# deprecated
+CONFIG_MANAGER = config_manager
 
 
 def _init():
-    CONFIG_MANAGER.load_config_file(str(pathlib.Path(__file__).parent / "hpgl_devices.toml"))
+    config_manager.load_config_file(str(pathlib.Path(__file__).parent / "hpgl_devices.toml"))
     path = os.path.expanduser("~/.vpype.toml")
     if os.path.exists(path):
-        CONFIG_MANAGER.load_config_file(str(path))
+        config_manager.load_config_file(str(path))
 
 
 _init()

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -15,7 +15,7 @@ from multiprocess import Pool
 from shapely.geometry import LineString
 from svgwrite.extensions import Inkscape
 
-from .config import CONFIG_MANAGER, PaperConfig, PlotterConfig
+from .config import PaperConfig, PlotterConfig, config_manager
 from .model import Document, LineCollection
 from .utils import UNITS
 
@@ -473,8 +473,8 @@ def _get_hpgl_config(
     device: Optional[str], page_size: str
 ) -> Tuple[PlotterConfig, PaperConfig]:
     if device is None:
-        device = CONFIG_MANAGER.get_command_config("write").get("default_hpgl_device", None)
-    plotter_config = CONFIG_MANAGER.get_plotter_config(str(device))
+        device = config_manager.get_command_config("write").get("default_hpgl_device", None)
+    plotter_config = config_manager.get_plotter_config(str(device))
     if plotter_config is None:
         raise ValueError(f"no configuration available for plotter '{device}'")
     paper_config = plotter_config.paper_config(page_size)

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -119,7 +119,7 @@ def cli(ctx, verbose, include, history, seed, config):
     random.seed(seed)
 
     if config is not None:
-        vp.CONFIG_MANAGER.load_config_file(config)
+        vp.config_manager.load_config_file(config)
 
 
 # noinspection PyShadowingNames,PyUnusedLocal

--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -59,7 +59,7 @@ When writing to HPGL, a device name must be provided with the `--device` option.
 corresponding device must be configured in the built-in or a user-provided configuration file
 (see the documentation for more details). The following devices are currently available:
 
-    {', '.join(vp.CONFIG_MANAGER.get_plotter_list())}
+    {', '.join(vp.config_manager.get_plotter_list())}
 
 In HPGL mode, this command will try to infer the paper size to use based on the current page
 size (the current page size is set by the `read` command based on the input file and can be
@@ -208,7 +208,7 @@ def write(
         )
     elif file_format == "hpgl":
         if not page_size:
-            config = vp.CONFIG_MANAGER.get_plotter_config(device)
+            config = vp.config_manager.get_plotter_config(device)
             if config is not None:
                 paper_config = config.paper_config_from_size(document.page_size)
             else:


### PR DESCRIPTION
#### Description

`CONFIG_MANAGER` being mutable, the upper-case notation is non-standard, thus the change to lower-case.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
