### PR TITLE
Added support for custom UI scale factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ New features and improvements:
   * Added rulers with dynamic scale to the display (can be optionally hidden) (#199)
   * Added metric and imperial unit system (in addition to pixels), used by the rulers and the mouse coordinate display (#199)
   * Adjusted the size of the mouse coordinates text on Windows (#199)
+  * Added support to scale the UI via `~/.vpype.toml` (#203)
+  
+    This can be achieved by adding the following lines to your `~/.vpype.toml` file:
+    ```toml
+    [viewer]
+    ui_scale_factor = 1.5
+    ```  
+    A value of 1.5 may be useful on some Windows configurations where the default UI is very small.
   
 API changes:
   * Renamed `vpype.CONFIG_MANAGER` in favour of `vpype.config_manager` (existing name kept for compatibility) (#202)

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -38,6 +38,17 @@ __all__ = ["QtViewerWidget", "QtViewer", "show"]
 _DEBUG_ENABLED = "VPYPE_VIEWER_DEBUG" in os.environ
 
 
+# handle UI scaling
+def _configure_ui_scaling():
+    viewer_config = vp.config_manager.config.get("viewer", {})
+    if "QT_SCALE_FACTOR" not in os.environ:
+        if "ui_scale_factor" in viewer_config:
+            os.environ["QT_SCALE_FACTOR"] = str(viewer_config["ui_scale_factor"])
+
+
+_configure_ui_scaling()
+
+
 class QtViewerWidget(QGLWidget):
     """QGLWidget wrapper around :class:`Engine` to display a :class:`vpype.Document` in
     Qt GUI."""

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -41,9 +41,8 @@ _DEBUG_ENABLED = "VPYPE_VIEWER_DEBUG" in os.environ
 # handle UI scaling
 def _configure_ui_scaling():
     viewer_config = vp.config_manager.config.get("viewer", {})
-    if "QT_SCALE_FACTOR" not in os.environ:
-        if "ui_scale_factor" in viewer_config:
-            os.environ["QT_SCALE_FACTOR"] = str(viewer_config["ui_scale_factor"])
+    if "QT_SCALE_FACTOR" not in os.environ and "ui_scale_factor" in viewer_config:
+        os.environ["QT_SCALE_FACTOR"] = str(viewer_config["ui_scale_factor"])
 
 
 _configure_ui_scaling()


### PR DESCRIPTION
#### Description

This PR adds the possibility to customize the UI scale factor in the `~/.vpype.toml` file with the following lines:

```toml
[viewer]
ui_scale_factor = 1.5
```

It appears that a value of 1.5 is good for Windows and may, in the future, be used as default.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
