### PR TITLE
Add max plot area note for 7440a

### DIFF
--- a/vpype/hpgl_devices.toml
+++ b/vpype/hpgl_devices.toml
@@ -101,4 +101,4 @@ x_range = [0, 11040]
 y_range = [0, 7721]
 y_axis_up = true
 origin_location = ["15mm", "200mm"]
-info = "The plotter dip switches must be set to Metric paper sizes mode."
+info = "Max plotable area before croping is 191mm x 268mm. The plotter dip switches must be set for Metric paper sizes."


### PR DESCRIPTION
#### Description

Added Note for max plottable area of 7440a

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
