### PR TITLE
Added linesort two-op operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ New features and improvements:
   pip install -U vpype       # the viewer and its dependencies is NOT installed
   ```
   Forgoing the viewer considerably reduces the number of required dependencies and may be useful for embedded (e.g. Raspberry Pi) and server installs of *vpype*, when the `show` command is not necessary.
+* Added optional global optimization feature to `linemerge` (#266, thanks to @tatarize)
+
+  This feature is enabled by adding the `--two-opt` option. Since it considerably increases the processing time for complex designs, it should primarily be used for special cases, for example when the same file must be plotted multiple times.
 
 Bug fixes:
 * Fixed systematic crash when using the Windows installer (#285)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -383,6 +383,28 @@ def test_linesort_result(runner, opt, expected):
     assert data.pen_up_length == pytest.approx(expected)
 
 
+def test_linesort_reject_bad_opt(runner):
+    res = runner.invoke(
+        cli,
+        "line 0 0 0 10 line 0 10 10 10 line 0 0 10 0 line 10 0 10 10 "
+        f"linesort --no-flip dbsample dbdump",
+    )
+
+    # in this situation, the greedy optimizer is worse than the starting position, so its
+    # result should be discarded
+
+    data = DebugData.load(res.output)[0]
+    assert res.exit_code == 0
+    assert data.pen_up_length == pytest.approx(14.1, abs=0.1)
+
+
+def test_linesort_two_opt_debug_output(runner, caplog):
+    res = runner.invoke(cli, "-vv -s 0 random -n 100 linesort --two-opt")
+
+    assert res.exit_code == 0
+    assert "% done with pass" in caplog.text
+
+
 def test_snap():
     line = np.array([0.2, 0.8 + 1.1j, 0.5 + 2.5j])
     lc = execute_single_line("snap 1", line)

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -166,7 +166,7 @@ def linesort(
         def delta_distance(j: int, k: int) -> float:
             distance = 0.0
             a1 = new_lines[j][0]
-            b0 = new_lines[k-1][-1]
+            b0 = new_lines[k - 1][-1]
             if k < len(new_lines):
                 b1 = new_lines[k][0]
                 d = np.abs(b0 - b1)
@@ -180,7 +180,7 @@ def linesort(
                 d = np.abs(a0 - b0)
                 distance += d
             return distance
-        
+
         improved = True
         while improved:
             passes -= 1
@@ -192,11 +192,6 @@ def linesort(
                             new_lines.lines[q] = np.flip(new_lines.lines[q])
                         new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
                         improved = True
-            logging.info(
-                f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
-                f"{new_lines.pen_up_length()}"
-            )
-            print(passes)
             if passes <= 0:
                 break
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -135,28 +135,29 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
     "--passes",
     type=int,
     default=250,
-    help="How many passes is the two-opt algorithm permitted to take?",
-)
-@click.option(
-    "-w",
-    "--work",
-    is_flag=True,
-    help="Show work progress within the two-opt algorithm",
+    help="Number of passes the two-opt algorithm is permitted to take (default: 250)",
 )
 @vp.layer_processor
-def linesort(
-    lines: vp.LineCollection,
-    no_flip: bool = True,
-    two_opt: bool = False,
-    passes: int = 250,
-    work: bool = False,
-):
+def linesort(lines: vp.LineCollection, no_flip: bool, two_opt: bool, passes: int):
     """
     Sort lines to minimize the pen-up travel distance.
 
-    Note: this process can be lengthy depending on the total number of line. Consider using
-    `linemerge` before `linesort` to reduce the total number of line and thus significantly
-    optimizing the overall plotting time.
+    This command reorders the paths within layers such as to minimize the total pen-up
+    distance. By default, it will also invert the path direction if it can further optimize the
+    pen-up distance. This behavior can be disabled using the `--no-flip` option.
+
+    By default, a fast, greedy algorithm is used. Although it will dramatically reduce the
+    pen-up distance in most situation, it trades execution speed for optimality. Further
+    optimization using the two-opt algorithm can be enabled using the `--two-opt` option. Since
+    this greatly increase processing time, this feature is mostly useful for special cases such
+    as when the same design must be plotted multiple times.
+
+    When using `--two-opt`, detailed progress indication are available in the debug output,
+    which is enabled using the `-vv` global option:
+
+        $ vpype -vv [...] linesort --two-opt [...]
+
+    Note: to further optimize the plotting time, consider using `linemerge` before `linesort`.
     """
     if len(lines) < 2:
         return lines
@@ -198,16 +199,18 @@ def linesort(
         indexes1 = indexes0 + 1
 
         # noinspection PyShadowingNames
-        def work_progress(pos):
+        def log_progress(pos):
+            # only compute progress if debug output is enable
+            if logging.getLogger().level > logging.DEBUG:
+                return
             starts = endpoints[indexes0, -1]
             ends = endpoints[indexes1, 0]
             dists = np.abs(starts - ends)
             dist_sum = dists.sum()
-            logging.info(
+            logging.debug(
                 f"optimize: pen-up distance is {dist_sum}. {100 * pos / length:.02f}% done "
                 f"with pass {current_pass}/{passes}"
             )
-            return dist_sum
 
         improved = True
         while improved:
@@ -224,8 +227,7 @@ def linesort(
                     endpoints[: index + 1], (0, 1)
                 )  # top to bottom, and right to left flips.
                 improved = True
-                if work:
-                    work_progress(1)
+                log_progress(1)
             for mid in range(1, length - 1):
                 idxs = np.arange(mid, length - 1)
 
@@ -245,8 +247,7 @@ def linesort(
                         endpoints[mid : mid + index + 1], (0, 1)
                     )
                     improved = True
-                    if work:
-                        work_progress(mid)
+                    log_progress(mid)
 
             last = endpoints[-1, -1]
             pen_ups = endpoints[indexes0, -1]
@@ -259,8 +260,7 @@ def linesort(
                     endpoints[index + 1 :], (0, 1)
                 )  # top to bottom, and right to left flips.
                 improved = True
-                if work:
-                    work_progress(length)
+                log_progress(length)
             if current_pass >= passes:
                 break
             current_pass += 1

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -128,18 +128,18 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
     "-t",
     "--two-opt",
     is_flag=True,
-    help="Use two-opt algorithm to perform distance minimization.",
+    help="Use two-opt algorithm to perform additional distance minimization.",
 )
 @click.option(
     "-p",
     "--passes",
     type=int,
-    default=5,
+    default=250,
     help="How many passes is the two-opt algorithm permitted to take?",
 )
 @vp.layer_processor
 def linesort(
-    lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = False, passes: int = 1000
+    lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = False, passes: int = 250
 ):
     """
     Sort lines to minimize the pen-up travel distance.
@@ -160,11 +160,6 @@ def linesort(
         if reverse:
             line = np.flip(line)
         new_lines.append(line)
-
-    logging.info(
-        f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
-        f"{new_lines.pen_up_length()}"
-    )
 
     if two_opt:
         length = len(new_lines)
@@ -225,20 +220,20 @@ def linesort(
             if passes <= 0:
                 break
         order = endpoints[:, 1]
-        reordered = [None] * length
+        reordered = list()
         for i in range(length):
             pos = int(order[i].real)
             if pos < 0:
                 pos = ~pos
                 new_lines.lines[pos] = np.flip(new_lines.lines[pos])
-            reordered[i] = new_lines.lines[pos]
+            reordered.append(new_lines.lines[pos])
         new_lines.lines.clear()
         new_lines.extend(reordered)
-        # new_lines._lines = new_lines._lines[order]
-        logging.info(
-            f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
-            f"{new_lines.pen_up_length()}"
-        )
+
+    logging.info(
+        f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
+        f"{new_lines.pen_up_length()}"
+    )
 
     return new_lines
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -124,8 +124,14 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
     is_flag=True,
     help="Disable reversing stroke direction for optimization.",
 )
+@click.option(
+    "-t",
+    "--two-opt",
+    is_flag=True,
+    help="Use two-opt algorithm to perform distance minimization.",
+)
 @vp.layer_processor
-def linesort(lines: vp.LineCollection, no_flip: bool = True):
+def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = False):
     """
     Sort lines to minimize the pen-up travel distance.
 
@@ -134,6 +140,44 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True):
     optimizing the overall plotting time.
     """
     if len(lines) < 2:
+        return lines
+
+    if two_opt:
+        def delta_distance(j: int, k: int) -> float:
+            distance = 0.0
+            k -= 1
+            a1 = lines[j][0]
+            b0 = lines[k][-1]
+            if k < len(lines) - 1:
+                b1 = lines[k + 1][0]
+                d = np.abs(b0 - b1)
+                distance -= d
+                d = np.abs(a1 - b1)
+                distance += d
+            if j > 0:
+                a0 = lines[j - 1][-1]
+                d = np.abs(a0 - a1)
+                distance -= d
+                d = np.abs(a0 - b0)
+                distance += d
+            return distance
+
+        original = lines.pen_up_length()
+        improved = True
+        while improved:
+            improved = False
+            for j in range(len(lines)):
+                for k in range(j + 1, len(lines)):
+                    if delta_distance(j, k) < 0:
+                        for q in range(j, k):
+                            lines.lines[q] = lines.lines[q][::-1]
+                        lines.lines[j:k] = lines.lines[j:k][::-1]
+                        improved = True
+
+        logging.info(
+            f"optimize: reduced pen-up (distance, mean, median) from {original} to "
+            f"{lines.pen_up_length()}"
+        )
         return lines
 
     index = vp.LineIndex(lines[1:], reverse=not no_flip)

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -143,6 +143,7 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
         return lines
 
     if two_opt:
+
         def delta_distance(j: int, k: int) -> float:
             distance = 0.0
             k -= 1

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -153,7 +153,7 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
         new_lines.append(line)
 
     if two_opt:
-        
+
         def delta_distance(j: int, k: int) -> float:
             distance = 0.0
             k -= 1
@@ -183,7 +183,6 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
                             new_lines.lines[q] = new_lines.lines[q][::-1]
                         new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
                         improved = True
-
 
     logging.info(
         f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -165,11 +165,10 @@ def linesort(
 
         def delta_distance(j: int, k: int) -> float:
             distance = 0.0
-            k -= 1
             a1 = new_lines[j][0]
-            b0 = new_lines[k][-1]
-            if k < len(new_lines) - 1:
-                b1 = new_lines[k + 1][0]
+            b0 = new_lines[k-1][-1]
+            if k < len(new_lines):
+                b1 = new_lines[k][0]
                 d = np.abs(b0 - b1)
                 distance -= d
                 d = np.abs(a1 - b1)
@@ -181,18 +180,23 @@ def linesort(
                 d = np.abs(a0 - b0)
                 distance += d
             return distance
-
+        
         improved = True
         while improved:
             passes -= 1
             improved = False
             for j in range(len(new_lines)):
-                for k in range(j + 1, len(new_lines)):
+                for k in range(j + 1, len(new_lines) + 1):
                     if delta_distance(j, k) < 0:
                         for q in range(j, k):
-                            np.flip(lines[q])
+                            new_lines.lines[q] = np.flip(new_lines.lines[q])
                         new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
                         improved = True
+            logging.info(
+                f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
+                f"{new_lines.pen_up_length()}"
+            )
+            print(passes)
             if passes <= 0:
                 break
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -130,8 +130,17 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
     is_flag=True,
     help="Use two-opt algorithm to perform distance minimization.",
 )
+@click.option(
+    "-p",
+    "--passes",
+    type=int,
+    default=5,
+    help="How many passes is the two-opt algorithm permitted to take?",
+)
 @vp.layer_processor
-def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = False):
+def linesort(
+    lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = False, passes: int = 1000
+):
     """
     Sort lines to minimize the pen-up travel distance.
 
@@ -175,14 +184,17 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
 
         improved = True
         while improved:
+            passes -= 1
             improved = False
             for j in range(len(new_lines)):
                 for k in range(j + 1, len(new_lines)):
                     if delta_distance(j, k) < 0:
                         for q in range(j, k):
-                            new_lines.lines[q] = new_lines.lines[q][::-1]
+                            np.flip(lines[q])
                         new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
                         improved = True
+            if passes <= 0:
+                break
 
     logging.info(
         f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -142,45 +142,6 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
     if len(lines) < 2:
         return lines
 
-    if two_opt:
-
-        def delta_distance(j: int, k: int) -> float:
-            distance = 0.0
-            k -= 1
-            a1 = lines[j][0]
-            b0 = lines[k][-1]
-            if k < len(lines) - 1:
-                b1 = lines[k + 1][0]
-                d = np.abs(b0 - b1)
-                distance -= d
-                d = np.abs(a1 - b1)
-                distance += d
-            if j > 0:
-                a0 = lines[j - 1][-1]
-                d = np.abs(a0 - a1)
-                distance -= d
-                d = np.abs(a0 - b0)
-                distance += d
-            return distance
-
-        original = lines.pen_up_length()
-        improved = True
-        while improved:
-            improved = False
-            for j in range(len(lines)):
-                for k in range(j + 1, len(lines)):
-                    if delta_distance(j, k) < 0:
-                        for q in range(j, k):
-                            lines.lines[q] = lines.lines[q][::-1]
-                        lines.lines[j:k] = lines.lines[j:k][::-1]
-                        improved = True
-
-        logging.info(
-            f"optimize: reduced pen-up (distance, mean, median) from {original} to "
-            f"{lines.pen_up_length()}"
-        )
-        return lines
-
     index = vp.LineIndex(lines[1:], reverse=not no_flip)
     new_lines = vp.LineCollection([lines[0]])
 
@@ -190,6 +151,39 @@ def linesort(lines: vp.LineCollection, no_flip: bool = True, two_opt: bool = Fal
         if reverse:
             line = np.flip(line)
         new_lines.append(line)
+
+    if two_opt:
+        
+        def delta_distance(j: int, k: int) -> float:
+            distance = 0.0
+            k -= 1
+            a1 = new_lines[j][0]
+            b0 = new_lines[k][-1]
+            if k < len(new_lines) - 1:
+                b1 = new_lines[k + 1][0]
+                d = np.abs(b0 - b1)
+                distance -= d
+                d = np.abs(a1 - b1)
+                distance += d
+            if j > 0:
+                a0 = new_lines[j - 1][-1]
+                d = np.abs(a0 - a1)
+                distance -= d
+                d = np.abs(a0 - b0)
+                distance += d
+            return distance
+
+        improved = True
+        while improved:
+            improved = False
+            for j in range(len(new_lines)):
+                for k in range(j + 1, len(new_lines)):
+                    if delta_distance(j, k) < 0:
+                        for q in range(j, k):
+                            new_lines.lines[q] = new_lines.lines[q][::-1]
+                        new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
+                        improved = True
+
 
     logging.info(
         f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -161,45 +161,81 @@ def linesort(
             line = np.flip(line)
         new_lines.append(line)
 
-    if two_opt:
-
-        def delta_distance(j: int, k: int) -> float:
-            distance = 0.0
-            a1 = new_lines[j][0]
-            b0 = new_lines[k - 1][-1]
-            if k < len(new_lines):
-                b1 = new_lines[k][0]
-                d = np.abs(b0 - b1)
-                distance -= d
-                d = np.abs(a1 - b1)
-                distance += d
-            if j > 0:
-                a0 = new_lines[j - 1][-1]
-                d = np.abs(a0 - a1)
-                distance -= d
-                d = np.abs(a0 - b0)
-                distance += d
-            return distance
-
-        improved = True
-        while improved:
-            passes -= 1
-            improved = False
-            for j in range(len(new_lines)):
-                for k in range(j + 1, len(new_lines) + 1):
-                    if delta_distance(j, k) < 0:
-                        for q in range(j, k):
-                            new_lines.lines[q] = np.flip(new_lines.lines[q])
-                        new_lines.lines[j:k] = new_lines.lines[j:k][::-1]
-                        improved = True
-            if passes <= 0:
-                break
-
     logging.info(
         f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
         f"{new_lines.pen_up_length()}"
     )
 
+    if two_opt:
+        length = len(new_lines)
+        endpoints = np.zeros((length, 4), dtype="complex")  # start, end, position
+        for i in range(length):
+            endpoints[i] = new_lines[i][0], i, ~i, new_lines[i][-1]
+        inc1 = np.arange(1, length)
+        ran0 = inc1 - 1
+        
+        improved = True
+        while improved:
+            passes -= 1
+            improved = False
+            a1 = endpoints[0][0]
+            b0 = endpoints[ran0,-1]
+            b1 = endpoints[inc1,0]
+            delta = np.abs(a1 - b1) - np.abs(b0 - b1)
+            index = np.argmin(delta)
+            v = delta[index]
+            if v < 0:
+                print(v)
+                endpoints[:index] = np.flip(endpoints[:index], (0,1))  # top to bottom, and right to left flips.
+                improved = True
+
+            b0 = endpoints[-1, -1]
+            a1 = endpoints[inc1, 0]
+            a0 = endpoints[ran0, -1]
+            delta = np.abs(a0 - b0) - np.abs(a0 - a1)
+            index = np.argmin(delta)
+            v = delta[index]
+            if v < 0:
+                print(v)
+                endpoints[:index] = np.flip(endpoints[:index], (0, 1))  # top to bottom, and right to left flips.
+                improved = True
+
+            for j in range(1, length):
+                k = np.arange(j+1, length)
+                a1 = endpoints[j,0]
+                a0 = endpoints[j - 1, -1]
+                b0 = endpoints[k - 1, -1]
+                b1 = endpoints[k,0]
+                delta = np.abs(a1 - b1) - np.abs(b0 - b1) - np.abs(a0 - a1) + np.abs(a0 - b0)
+                print(delta.shape)
+                if len(delta) == 0:
+                    continue
+                index = np.argmin(delta)
+                v = delta[index]
+                if v < 0:
+                    print(v)
+                    endpoints[j:index] = np.flip(endpoints[j:index], (0,1))
+                    improved = True
+            print(endpoints)
+            print(passes)
+            if passes <= 0:
+                break
+        complex_order = endpoints[:,1]
+        order = np.zeros(len(endpoints), dtype='int')
+        for i in range(len(endpoints)):
+            pos = int(complex_order[i].real)
+            if pos < 0:
+                pos = ~pos
+                new_lines.lines[pos] = new_lines.lines[pos]
+            order[i] = pos
+        print(order)
+        print(new_lines)
+        # new_lines._lines = new_lines._lines[order]
+        logging.info(
+            f"optimize: reduced pen-up (distance, mean, median) from {lines.pen_up_length()} to "
+            f"{new_lines.pen_up_length()}"
+        )
+        
     return new_lines
 
 


### PR DESCRIPTION
#### Description

Adds in a flag for the linesort command to perform two-opt global distance minimization.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
