### PR TITLE
HPGL: change velocity to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 #### 1.7 (UNRELEASED)
 
-**Important**: for a normal installation, *vpype* must now be installed/updated with the following command:
+**Important**: for a regular installation, *vpype* must now be installed/updated with the following command:
 ```
 pip install -U vpype[all]
 ```
-
 
 New features and improvements:
 * The viewer (`show` command) and its dependencies is no longer required and is installed only if the `all` extra is provided to `pip`:
@@ -20,6 +19,7 @@ Bug fixes:
 * Fixed systematic crash when using the Windows installer (#285)
 * Fixed an issue where `read` would crash with empty `<polygon>` tags and similar degenerate geometries (#260)
 * Fixed an issue where `linesimplify` would skip layers containing a single line (#280)
+* Fixed an issue where floating point value could be generated for HPGL VS commands (#286)
 
 Other changes:
 * Updated to Click 8.0.1 (#282) 

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,7 +57,7 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "black"
-version = "21.5b1"
+version = "21.5b2"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -75,8 +75,9 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.6.0)", "aiohttp-cors"]
+d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
 python2 = ["typed-ast (>=1.4.2)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cachetools"
@@ -225,7 +226,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.3.1"
+version = "4.5.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -546,18 +547,19 @@ histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.12.0"
+version = "2.12.1"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
+coverage = ">=5.2.1"
 pytest = ">=4.6"
+toml = "*"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mpl"
@@ -936,8 +938,8 @@ babel = [
     {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 black = [
-    {file = "black-21.5b1-py3-none-any.whl", hash = "sha256:8a60071a0043876a4ae96e6c69bd3a127dad2c1ca7c8083573eb82f92705d008"},
-    {file = "black-21.5b1.tar.gz", hash = "sha256:23695358dbcb3deafe7f0a3ad89feee5999a46be5fec21f4f1d108be0bcdb3b1"},
+    {file = "black-21.5b2-py3-none-any.whl", hash = "sha256:e5cf21ebdffc7a9b29d73912b6a6a9a4df4ce70220d523c21647da2eae0751ef"},
+    {file = "black-21.5b2.tar.gz", hash = "sha256:1fc0e0a2c8ae7d269dfcf0c60a89afa299664f3e811395d40b1922dff8f854b5"},
 ]
 cachetools = [
     {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
@@ -1061,8 +1063,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.3.1-py3-none-any.whl", hash = "sha256:c2e27fa8b6c8b34ebfcd4056ae2ca290e36250d1fbeceec85c1c67c711449fac"},
-    {file = "importlib_metadata-4.3.1.tar.gz", hash = "sha256:2d932ea08814f745863fd20172fe7de4794ad74567db78f2377343e24520a5b6"},
+    {file = "importlib_metadata-4.5.0-py3-none-any.whl", hash = "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00"},
+    {file = "importlib_metadata-4.5.0.tar.gz", hash = "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1357,8 +1359,8 @@ pytest-benchmark = [
     {file = "pytest_benchmark-3.4.1-py2.py3-none-any.whl", hash = "sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.12.0.tar.gz", hash = "sha256:8535764137fecce504a49c2b742288e3d34bc09eed298ad65963616cc98fd45e"},
-    {file = "pytest_cov-2.12.0-py2.py3-none-any.whl", hash = "sha256:95d4933dcbbacfa377bb60b29801daa30d90c33981ab2a79e9ab4452c165066e"},
+    {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
+    {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
 pytest-mpl = [
     {file = "pytest-mpl-0.12.tar.gz", hash = "sha256:4a223909e5148c99bd18891848c7871457729322c752c9c470bd8dd6bdf9f940"},

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -494,7 +494,7 @@ def write_hpgl(
     landscape: bool,
     center: bool,
     device: Optional[str],
-    velocity: Optional[float],
+    velocity: Optional[int],
     quiet: bool = False,
 ) -> None:
     """Create a HPGL file from the :class:`Document` instance.
@@ -608,7 +608,7 @@ def write_hpgl(
 
     output.write("IN;DF;")
     if velocity is not None:
-        output.write(f"VS{velocity};")
+        output.write(f"VS{int(velocity)};")
     if paper_config.set_ps is not None:
         output.write(f"PS{int(paper_config.set_ps)};")
 

--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -152,7 +152,7 @@ Examples:
 @click.option(
     "-vs",
     "--velocity",
-    type=float,
+    type=int,
     help="[HPGL only] Emit a VS command with the provided value.",
 )
 @click.option(


### PR DESCRIPTION
#### Description

- `write -f hpgl` now only accepts int for `-velocity/--vs`
- HPGL outputs `VS` command with int value only

Fixes #255

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
