### PR TITLE
Fixed aliasing issue with relative HPGL export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 New features and improvements:
 * Added `lswap` command to swap the content of two layers (#300)
 * Added `lreverse` command to reverse the order of paths within a layer (#300)
-* Improved HPGL export (#253, #310, #316)
+* Improved HPGL export (#253, #310, #316, #335)
 
   * Relative coordinates are now used by default to reduce file size. If absolute coordinates are needed, they a new `--absolute` option for the `write` command.
   * A homing command (as defined by the `final_pu_params` configuration parameter) is no longer emitted between layers.

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -635,6 +635,10 @@ def write_hpgl(
                     + ";"
                 )
             else:
+                # snap all points of the line to the HPGL grid, such as to avoid any aliasing
+                # when computing the diff between points
+                line = np.round(line)
+
                 if last_point is None:
                     output.write(f"PU{complex_to_str(line[0])};PR;")
                 else:


### PR DESCRIPTION
#### Description

Lack of proper rounding could yield aliasing issues with relative export.

To reproduce:
```
vpype -v begin grid -o 0 0.11mm 1 1200 line 0 0 0 0.11mm end linemerge translate 0.1cm 0 line 0 0 0 13.2cm linemerge layout a4 write -d hp7475a test.hpgl
```
Both lines should be the same length but the first one is shorter when exported in HPGL without  `--absolute`.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
