### PR TITLE
Fix viewer crash with empty layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ cython_debug/
 /W3C_SVG_11_TestSuite
 /my_work
 /pip-wheel-metadata
+/test_report_img_sim/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ New features and improvements:
 
 Bug fixes:
 * Fixed issue with HPGL export where page size auto-detection would fail when using the default device from the config file (instead of specifying the device with `--device`) (#328)
+* Fixed issue where the viewer would crash with empty layers (#339) 
 
 
 #### 1.7 (2021-06-10)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -14,6 +14,38 @@ from vpype_viewer import (
 
 from .utils import TEST_FILE_DIRECTORY
 
+RENDER_KWARGS = [
+    pytest.param({"view_mode": ViewMode.OUTLINE}, id="outline"),
+    pytest.param({"view_mode": ViewMode.OUTLINE_COLORFUL}, id="outline_colorful"),
+    pytest.param({"view_mode": ViewMode.PREVIEW}, id="preview"),
+    pytest.param({"view_mode": ViewMode.OUTLINE, "show_points": True}, id="points"),
+    pytest.param(
+        {"view_mode": ViewMode.OUTLINE_COLORFUL, "show_points": True}, id="colorful_points"
+    ),
+    pytest.param({"view_mode": ViewMode.OUTLINE, "show_pen_up": True}, id="outline_pen_up"),
+    pytest.param({"view_mode": ViewMode.PREVIEW, "show_pen_up": True}, id="preview_pen_up"),
+    pytest.param(
+        {"view_mode": ViewMode.PREVIEW, "pen_opacity": 0.3}, id="preview_transparent"
+    ),
+    pytest.param({"view_mode": ViewMode.PREVIEW, "pen_width": 4.0}, id="preview_thick"),
+    pytest.param(
+        {"view_mode": ViewMode.OUTLINE, "show_ruler": True, "unit_type": UnitType.PIXELS},
+        id="outline_pixels",
+    ),
+    pytest.param(
+        {"view_mode": ViewMode.OUTLINE, "show_ruler": True, "unit_type": UnitType.METRIC},
+        id="outline_metric",
+    ),
+    pytest.param(
+        {
+            "view_mode": ViewMode.OUTLINE,
+            "show_ruler": True,
+            "unit_type": UnitType.IMPERIAL,
+        },
+        id="outline_imperial",
+    ),
+]
+
 
 # assert_image_similarity fixture added for automated exclusion on unsupported runner
 def test_viewer_engine_properties(assert_image_similarity):
@@ -67,49 +99,19 @@ def test_viewer_engine_properties(assert_image_similarity):
     ["misc/empty.svg", "misc/multilayer.svg", "issue_124/plotter.svg"],
     ids=lambda s: os.path.splitext(s)[0],
 )
-@pytest.mark.parametrize(
-    "render_kwargs",
-    [
-        pytest.param({"view_mode": ViewMode.OUTLINE}, id="outline"),
-        pytest.param({"view_mode": ViewMode.OUTLINE_COLORFUL}, id="outline_colorful"),
-        pytest.param({"view_mode": ViewMode.PREVIEW}, id="preview"),
-        pytest.param({"view_mode": ViewMode.OUTLINE, "show_points": True}, id="points"),
-        pytest.param(
-            {"view_mode": ViewMode.OUTLINE_COLORFUL, "show_points": True}, id="colorful_points"
-        ),
-        pytest.param(
-            {"view_mode": ViewMode.OUTLINE, "show_pen_up": True}, id="outline_pen_up"
-        ),
-        pytest.param(
-            {"view_mode": ViewMode.PREVIEW, "show_pen_up": True}, id="preview_pen_up"
-        ),
-        pytest.param(
-            {"view_mode": ViewMode.PREVIEW, "pen_opacity": 0.3}, id="preview_transparent"
-        ),
-        pytest.param({"view_mode": ViewMode.PREVIEW, "pen_width": 4.0}, id="preview_thick"),
-        pytest.param(
-            {"view_mode": ViewMode.OUTLINE, "show_ruler": True, "unit_type": UnitType.PIXELS},
-            id="outline_pixels",
-        ),
-        pytest.param(
-            {"view_mode": ViewMode.OUTLINE, "show_ruler": True, "unit_type": UnitType.METRIC},
-            id="outline_metric",
-        ),
-        pytest.param(
-            {
-                "view_mode": ViewMode.OUTLINE,
-                "show_ruler": True,
-                "unit_type": UnitType.IMPERIAL,
-            },
-            id="outline_imperial",
-        ),
-    ],
-)
+@pytest.mark.parametrize("render_kwargs", RENDER_KWARGS)
 def test_viewer(assert_image_similarity, file, render_kwargs):
     doc = vp.read_multilayer_svg(str(TEST_FILE_DIRECTORY / file), 0.4)
 
     # noinspection PyArgumentList
     assert_image_similarity(render_image(doc, (1024, 1024), **render_kwargs))
+
+
+@pytest.mark.parametrize("render_kwargs", RENDER_KWARGS)
+def test_viewer_empty_layer(render_kwargs):
+    doc = vp.Document()
+    doc.add(vp.LineCollection(), 1)
+    render_image(doc, (1024, 1024))
 
 
 def test_viewer_zoom_scale(assert_image_similarity):

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -108,7 +108,8 @@ def test_viewer(assert_image_similarity, file, render_kwargs):
 
 
 @pytest.mark.parametrize("render_kwargs", RENDER_KWARGS)
-def test_viewer_empty_layer(render_kwargs):
+def test_viewer_empty_layer(assert_image_similarity, render_kwargs):
+    # Note: assert_image_similarity added to avoid running CI tests on Linux
     doc = vp.Document()
     doc.add(vp.LineCollection(), 1)
     render_image(doc, (1024, 1024), **render_kwargs)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -111,7 +111,7 @@ def test_viewer(assert_image_similarity, file, render_kwargs):
 def test_viewer_empty_layer(render_kwargs):
     doc = vp.Document()
     doc.add(vp.LineCollection(), 1)
-    render_image(doc, (1024, 1024))
+    render_image(doc, (1024, 1024), **render_kwargs)
 
 
 def test_viewer_zoom_scale(assert_image_similarity):

--- a/vpype_viewer/engine.py
+++ b/vpype_viewer/engine.py
@@ -427,7 +427,11 @@ class Engine:
             color_index = 0
             for layer_id in sorted(self._document.layers):
                 layer_color: ColorType = _COLORS[color_index % len(_COLORS)]
+                color_index += 1
+
                 lc = self._document.layers[layer_id]
+                if lc.is_empty():
+                    continue
 
                 if self.view_mode == ViewMode.OUTLINE:
                     self._layer_painters[layer_id].append(
@@ -462,8 +466,6 @@ class Engine:
                     self._layer_painters[layer_id].append(
                         LineCollectionPointsPainter(self._ctx, lc=lc, color=layer_color)
                     )
-
-                color_index += 1
 
             page_size = self._document.page_size
             if page_size is not None:


### PR DESCRIPTION
#### Description

The viewer crashes when presented with empty layers (eg due to crop).

Fixes #338

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy vpype vpype_cli tests` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
