### PR TITLE
Various doc improvements for 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features and improvements:
 
 Other changes:
 * Changed dependencies to dataclasses (instead of attrs) and tomli (instead of toml) (#362)
+* Various documentation improvements (#363)
 
 
 #### 1.8 (2021-11-25)

--- a/README.md
+++ b/README.md
@@ -132,25 +132,21 @@ set, but makes its use for, e.g., printed media limited.
  
 ## Installation
 
-For Windows, an installer is available [here](https://github.com/abey79/vpype/releases) (note: plug-ins cannot be installed
+Detailed installation instructions are available in the [latest documentation](https://vpype.readthedocs.io/en/latest/install.html).
+
+TL;DR:
+- Python 3.9 is recommended, but *vpype* is also compatible with Python 3.7 and 3.8. *vpype* is **not** compatible with Python 3.10 yet. 
+- *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed with the following command (preferably in a virtual environment):
+  ```bash
+  pip install "vpype[all]"
+  ```
+- A Windows installer is available [here](https://github.com/abey79/vpype/releases) (plug-ins cannot be installed
 when using this installation method).
-
-For other platforms, and when plug-ins are required, *vpype* can be installed from the [Python Package Index](https://pypi.org)
-using the following command:
-
-```bash
-pip install vpype[all]
-```
-
-**Note**: a CLI-only version of *vpype* can be installed using `pip install vpype`. This version does not include the [`show`](https://vpype.readthedocs.io/en/stable/reference.html#show) command and skips the related dependencies (notably matplotlib, PySide2, and ModernGL). 
-
-Python must previously be installed. Python version 3.9.1 or later is recommended to use *vpype*, although it is also compatible with Python 3.6 and later.
-
-For Linux, install Python with your OS's default package manager. For macOS, Python is best installed from either
-[MacPorts](https://www.macports.org) or [Homebrew](https://brew.sh). For Windows, use the
-[official installer](https://www.python.org/downloads/).
-
-Check [the documentation](https://vpype.readthedocs.io/en/stable/install.html) for more details, in particular on how to use a virtual environment (recommended).
+- A CLI-only version of *vpype* can be installed using the following command:
+  ```bash
+  pip install vpype
+  ```
+  This version does not include the [`show`](https://vpype.readthedocs.io/en/stable/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide2, and ModernGL).
 
 
 ## Documentation

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+preview:
+	open _build/html/index.html
+
+clean:
+	rm -rf _build
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -125,6 +125,40 @@ removed thanks to the :ref:`cmd_filter` command::
   $ vpype read input.svg filter --min-length 0.5mm write output.svg
 
 
+.. _faq_custom_config_file:
+
+Creating a custom configuration file
+====================================
+
+Some of *vpype*'s features (such as HPGL export) or plug-in (such as `vpype-gcode <https://github.com/plottertools/vpype-gcode>`_) can be customized using a configuration file using the `TOML <https://toml.io/en/>`_ format. The documentation of the features or plug-in using such a configuration file explains what it should contain. This section focuses on how a custom config file is made available to *vpype*.
+
+The most common way is to create a `.vpype.toml` file at the root of your user directory, e.g.:
+
+- ``C:\Users\username\.vpype.toml`` on Windows
+- ``/Users/username/.vpype.toml`` on Mac
+- ``/home/username/.vpype.toml`` on Linux
+
+If such a file exists, it will be automatically loaded by *vpype* whenever it is used.
+
+.. note::
+
+   The ``.`` prefix in the file name will make the file **hidden** on most systems. This naming is typical for configuration files in the Unix world.
+
+
+Alternatively, a configuration file may be provided upon invocation of *vpype* using the ``--confg`` option (or ``-c`` for short), e.g.::
+
+  (vpype_venv) $ vpype --config my_config_file.toml [...]
+
+Note that *vpype* does not "remember" of such configuration file and the ``--config`` option and it must be specified on each invocation.
+
+.. note::
+
+   *vpype* is bundled with a `configuration file <https://github.com/abey79/vpype/blob/master/vpype/hpgl_devices.toml>`_. It is strongly discouraged to edit this file as it will be overwritten each time *vpype* is installed or updated.
+
+
+
+
+
 Converting a SVG to HPGL
 ========================
 
@@ -155,8 +189,8 @@ Defining a default HPGL plotter device
 ======================================
 
 If you are using the same type of plotter regularly, it may be cumbersome to systematically add the :option:`--device
-<write --device>` option to the :ref:`cmd_write` command. The default device can be set in the ``~/.vpype.toml``
-configuration file by adding the following section:
+<write --device>` option to the :ref:`cmd_write` command. The default device can be set in a configuration file (see
+:ref:`faq_custom_config_file`) by adding the following section:
 
   .. code-block:: toml
 
@@ -169,12 +203,9 @@ configuration file by adding the following section:
 Creating a custom configuration file for a HPGL plotter
 =======================================================
 
-The configuration for a number of HPGL plotter is bundled with vpype (run ``vpype write --help`` for a list). If your
-plotter is not included, it is possible to define your own plotter configuration either in `~/.vpype.toml` or any other
-file. In the latter case, you must instruct vpype to load the configuration using the :option:`--config <vpype
---config>` global option::
-
-  $ vpype --config my_config_file.toml read input.svg [...] write --device my_plotter --page-size a4 output.hpgl
+The configuration for a number of HPGL plotter is bundled with *vpype* (run ``vpype write --help`` for a list). If your
+plotter is not included, it is possible to define your own plotter configuration in a custom configuration file
+(see :ref:`faq_custom_config_file`).
 
 The configuration file must first include a plotter section with the following format:
 
@@ -258,7 +289,7 @@ Using arbitrary paper size with HPGL output
 ===========================================
 
 Some plotters such as the Calcomp Designmate support arbitrary paper sizes. Exporting HPGL with arbitrary paper size
-requires a specific paper configuration. vpype ships with the ``flex`` and ``flexl`` configurations for the
+requires a specific paper configuration. *vpype* ships with the ``flex`` and ``flexl`` configurations for the
 Designmate, which can serve as examples to create configurations for other plotters.
 
 For arbitrary paper size, the paper configuration must omit the ``paper_size`` parameter and specify a value for
@@ -292,7 +323,7 @@ Batch processing many SVG with bash scripts and ``parallel``
 ============================================================
 
 Computers offer endless avenues for automation, which depend on OS and the type of task at hand. Here is one way to
-easily process a large number of SVG with the same vpype pipeline. This approach relies on the
+easily process a large number of SVG with the same *vpype* pipeline. This approach relies on the
 `GNU Parallel <https://www.gnu.org/software/parallel/>`_ software and is best suited to Unix/Linux/macOS computers.
 Thanks to ``parallel``, this approach takes advantage of all available processing cores.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,40 +6,127 @@ Installation
 
 This page explain how to install *vpype* for end-users. If you intend to develop on *vpype*, refer to the the :ref:`contributing` section.
 
+.. caution::
 
-macOS
-=====
+    *vpype* is currently **not compatible with Python 3.10**. The recommended version is Python 3.9.9 (or later in the 3.9 series). *vpype* is
+    also compatible with Python 3.8 and 3.7.
+
+.. note::
+
+   The preferred way to install *vpype* is in a dedicated `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_. The present installation instructions always include this step.
+
+
+macOS (Apple Silicon/M1)
+========================
 
 .. highlight:: bash
 
-While macOS ships with a version of Python, this has been deprecated by Apple and may change in future version. Instead, you should install Python (3.9.1 or newer recommended, 3.6 minimum), either from `MacPorts <https://www.macports.org>`_ or from `Homebrew <https://brew.sh>`_. For macOS Big Sur, Python 3.9.1 or newer is required.
+Installing *vpype* on Macs with Apple Silicon is possible but requires specific steps because some its dependencies are not yet fully supported on this architecture. As a result, the Python interpreter *must* be installed from `MacPorts <https://www.macports.org>`_.
 
-Use the following commands for Homebrew::
+After `installing MacPorts <https://www.macports.org/install.php>`_, make sure its port database is up-to-date::
 
-  $ brew install python@3.9
+  $ sudo port selfupdate
+  $ sudo port upgrade outdated
 
-And for MacPorts::
+Then, install the required ports::
 
-  $ sudo port install python39
+  $ sudo port install python39 py39-shapely py39-scipy py39-numpy py39-pyside2
 
-Then, the preferred way to install *vpype* is in a dedicated `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_. Follow these steps to do so::
+Optionally, you may make Python 3.9 the default interpreter::
 
-  $ python3 -m venv vpype_venv      # create a new virtual environment
-  $ source vpype_venv/bin/activate  # activate the newly created virtual environment
-  $ pip install --upgrade pip
-  $ pip install 'vpype[all]'
+  $ sudo port select --set python python39
 
-You should now be able to run *vpype*::
+Then, create the virtual environment::
 
-  $ vpype --help
+  $ /opt/local/bin/python3.9 -m venv vpype_venv --system-site-packages
 
-Each time a new terminal window is opened, the virtual environment must be activated using::
+A virtual environment named ``vpype_venv`` will be created in the current directory. There are two import points to note in the command above.
+First, we use a full path (``/opt/local/bin/python3.9``) to ascertain that the virtual environment will use the right Python interpreter (i.e. MacPorts'). Second, we allow the virtual environment to use the global environment's packages (``--system-site-packages``). This is important because *vpype* needs MacPorts' version of PySide2 (``pip`` is unable to install PySide2 on Apple Silicon hardware).
+
+Now that the virtual environment is created, it may be activated::
 
   $ source vpype_venv/bin/activate
 
-Alternatively, *vpype* can be executed using the full path to the executable::
+Finally, *vpype* may be installed (note the prompt now reflecting the activated virtual environment)::
+
+  (vpype_venv) $ pip install "vpype[all]"
+
+You can test that *vpype* is fully functional by checking its version and displaying some random lines::
+
+  (vpype_venv) $ vpype --version
+  vpype 1.8.0
+  (vpype_venv) $ vpype random show
+
+Since *vpype* is installed within a virtual environment, it must be activated each time a new terminal window is opened::
+
+  $ source vpype_venv/bin/activate
+
+Alternatively, *vpype* can be executed without activating the virtual environment by using the full path to the executable::
 
   $ /path/to/vpype_venv/bin/vpype --help
+
+
+macOS (Intel)
+=============
+
+The instructions above also apply but, since dependencies have better support for Intel-based Macs, some steps may be simplified.
+
+Firstly, the `official Python distribution <https://www.python.org/downloads/>`_ may be used instead of MacPorts' (again, install Python 3.9 and avoid Python 3.10 as *vpype* is not yet compatible). Secondly, ``pip`` will successfully install all dependencies so using system packages is not required.
+
+Using MacPorts
+--------------
+
+After `installing MacPorts <https://www.macports.org/install.php>`_, make sure its port database is up-to-date::
+
+  $ sudo port selfupdate
+  $ sudo port upgrade outdated
+
+Then, install the required ports::
+
+  $ sudo port install python39
+
+Optionally, you may make Python 3.9 the default interpreter::
+
+  $ sudo port select --set python python39
+
+Create the virtual environment using the full path to the python interpreter::
+
+  $ /opt/local/bin/python3.9 -m venv vpype_venv
+
+
+Using the official Python distribution
+--------------------------------------
+
+After running the Python installer, the virtual environment can readily be created::
+
+  $ /Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m venv vpype_venv
+
+
+Activating the virtual environment and installing *vpype*
+---------------------------------------------------------
+
+Activate the virtual environment::
+
+  $ source vpype_venv/bin/activate
+
+Install *vpype* (note the prompt now reflecting the activated virtual environment)::
+
+  (vpype_venv) $ pip install "vpype[all]"
+
+You can test that *vpype* is fully functional by checking its version and displaying some random lines::
+
+  (vpype_venv) $ vpype --version
+  vpype 1.8.0
+  (vpype_venv) $ vpype random show
+
+Since *vpype* is installed within a virtual environment, it must be activated each time a new terminal window is opened::
+
+  $ source vpype_venv/bin/activate
+
+Alternatively, *vpype* can be executed without activating the virtual environment by using the full path to the executable::
+
+  $ /path/to/vpype_venv/bin/vpype --help
+
 
 
 Windows
@@ -47,24 +134,11 @@ Windows
 
 .. highlight:: bat
 
-A Windows installer is available `here <https://github.com/abey79/vpype/releases>`__. Although this installation method is easier, it does not allow plug-ins to be installed. If plug-ins are required, a manual installation is recommended.
+A Windows installer is `available here <https://github.com/abey79/vpype/releases>`__. Although this installation method is easier, it does not allow plug-ins to be installed. If plug-ins are required, a manual installation is recommended.
 
-First, Python must be installed. Python 3.9 is recommended, although it is also compatible with Python 3.6 and later. The official Python distribution for Windows can be downloaded `here <https://www.python.org/downloads/>`__.
+First, Python must be installed. Python 3.9 is recommended, although it is also compatible with Python 3.7 and later. The official Python distribution for Windows can be `downloaded here <https://www.python.org/downloads/>`__.
 
-After installing Python, launch a terminal (by typing ``cmd`` in the Start menu) and enter the following command to install *vpype*::
-
-  > pip install vpype[all]
-
-You should then be able to run *vpype*::
-
-  > vpype --help
-
-Installing in a virtual environment
------------------------------------
-
-`Virtual environment <https://docs.python.org/3/tutorial/venv.html>`_ are used to isolate the dependencies of one project from the the rest of your Python installation. Unless your Python installation is essentially dedicated to *vpype*, installing it in a virtual environment rather than in the global scope is preferable to avoid interferences.
-
-To create a virtual environment for your *vpype* installation, launch the ``cmd`` terminal and enter the following commands::
+First, create a virtual environment for your *vpype* installation, launch the ``cmd`` terminal and enter the following commands::
 
   > python -m venv vpype_venv
 
@@ -74,15 +148,17 @@ This will create a ``vpype_venv`` directory which will contain everything needed
 
 You will need to activate your virtual environment each time you launch a new  terminal. With your virtual environment activated, type the following command to install *vpype*::
 
-  > pip install vpype[all]
+  (vpype_venv) > pip install vpype[all]
+
+Note how the prompt now reflect the fact that the ``vpype_venv`` virtual environment is currently active.
 
 You should now be able to use *vpype*. Type this for a list of command::
 
-  > vpype --help
+  (vpype_venv) > vpype --help
 
 This command should open a window showing a circle::
 
-  > vpype circle 0 0 10cm show
+  (vpype_venv) > vpype circle 0 0 10cm show
 
 If you can see it, your installation is up and running!
 
@@ -92,7 +168,7 @@ Linux
 
 .. highlight:: bash
 
-*vpype* requires Python 3.6 or later. On Debian/ubuntu flavored installation, installing Python is a matter of::
+First, you must ensure that a Python interpreter with compatible version (3.7 to 3.9) is installed on your system. This is best done using your system's package manager. On Debian/ubuntu flavored installation, this is typically done as follows::
 
   $ sudo apt-get install python3 python3-pip
 
@@ -100,8 +176,8 @@ The preferred way to install *vpype* is in a dedicated `virtual environment <htt
 
   $ python3 -m venv vpype_venv      # create a new virtual environment
   $ source vpype_venv/bin/activate  # activate the newly created virtual environment
-  $ pip install --upgrade pip
-  $ pip install 'vpype[all]'
+  (vpype_venv) $ pip install --upgrade pip
+  (vpype_venv) $ pip install 'vpype[all]'
 
 You should now be able to run *vpype*::
 
@@ -136,8 +212,8 @@ Then, create a virtual environment with access to the globally installed package
 Finally, activate the virtual environment, install, and run *vpype*::
 
   $ source vpype_venv/bin/activate
-  $ pip install vpype
-  $ vpype --help
+  (vpype_venv) $ pip install vpype
+  (vpype_venv) $ vpype --help
 
 
 CLI-only install

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -85,7 +85,7 @@ class GroupedGroup(click.Group):
     "-H",
     "--history",
     is_flag=True,
-    help="Record this command in a `vpype_history.txt` in the current directory.",
+    help="Record this command in a `vpype_history.txt` file in the current directory.",
 )
 @click.option("-s", "--seed", type=int, help="Specify the RNG seed.")
 @click.option(
@@ -93,7 +93,43 @@ class GroupedGroup(click.Group):
 )
 @click.pass_context
 def cli(ctx, verbose, include, history, seed, config):
-    """Execute the vector processing pipeline passed as argument."""
+    """Execute the sequence of commands passed in argument.
+
+    The available commands are listed below. Information on each command may be obtained using:
+
+        vpype COMMAND --help
+
+    Some of vpype's commands or plug-ins may rely on a random number generator (RNG). By
+    default, vpype's RNG is seeded with the current time, such as to produce
+    pseudo-random behaviour. The seed can instead be set to a specific value (using
+    the `--seed` option) when reproducible behaviour is needed. For example, the following
+    always yields the exact same result:
+
+        vpype -s 0 random show
+
+    Include files (commonly named with the `.vpy` extension) can be used instead passing
+    commands in the command line, e.g.:
+
+        vpype read input.svg -I my_post_processing.vpy write.output.svg
+
+    Some commands and plug-in can be customized via a TOML configuration file. If a file named
+    `.vpype.toml` exists at the root of the user directory, vpype will automatically load it.
+    Alternatively, a custom configuration file may be loaded with the `--config` option, e.g.:
+
+        vpype -c my_plotter_config.toml read input.svg write -d my_plotter output.hpgl
+
+    When using the `--history` option, vpype will append its invocation (i.e. the full command
+    line) in a `vpype_history.txt` file in the current directory (creating it if necessary).
+    This may be useful to easily keep a trace of how project might have been created or
+    post-processed with vpype.
+
+    By default, vpype verbosity is low. It may be increased by using the `-v` option once or
+    twice to increase verbosity to info, respectively debug level, e.g.:
+
+        vpype -vv [...]
+
+    Refer to the documentation at https://vpype.readthedocs.io/ for more information.
+    """
 
     logging.basicConfig()
     if verbose == 0:

--- a/vpype_cli/transforms.py
+++ b/vpype_cli/transforms.py
@@ -93,6 +93,9 @@ def scale_relative(
     option, only these layers will be affected. In this case, the bounding box is that of the
     listed layers.
 
+    Note: negative scale factors are possible, but the end-of-options marker `--` must be used
+    to disambiguate the minus sign, which would normally be interpreted as a command option.
+
     Example:
 
         Double the size of the geometries in layer 1, using (0, 0) as origin:
@@ -226,6 +229,9 @@ def rotate(
     By default, act on all layers. If one or more layer IDs are provided with the `--layer`
     option, only these layers will be affected. In this case, the bounding box is that of the
     listed layers.
+
+    Note: negative angles are possible, but the end-of-options marker `--` must be used
+    to disambiguate the minus sign, which would normally be interpreted as a command option.
     """
 
     try:
@@ -275,6 +281,9 @@ def skew(
 
     The origin used in the bounding box center, unless the `--centroid` or `--origin` options
     are used.
+
+    Note: negative angles are possible, but the end-of-options marker `--` must be used
+    to disambiguate the minus sign, which would normally be interpreted as a command option.
     """
 
     try:

--- a/vpype_cli/transforms.py
+++ b/vpype_cli/transforms.py
@@ -41,6 +41,20 @@ def translate(lc: vp.LineCollection, offset: Tuple[float, float]):
     """
     Translate the geometries. X and Y offsets must be provided. These arguments understand
     supported units.
+
+    Note: negative offsets are possible, but the end-of-options marker `--` must be used to
+    disambiguate the minus sign, which would normally be interpreted as a command option (see
+    example below).
+
+    Examples:
+
+        Translate layer 2 by 2cm rightward and 3cm downward:
+
+            vpype [...] translate -l 2 2cm 3cm [...]
+
+        The end-of-options marker must be used for negative lateral offsets:
+
+            vpype [...] translate -- -2cm 3cm [...]
     """
     lc.translate(offset[0], offset[1])
     return lc


### PR DESCRIPTION
#### Description

- [x] `transform`, `scale`, `rotate`, `skew`: added note/example for negative offset and `--`
- [x] Update mac install instructions (remove homebrew, add/test official installer, M1 specific instructions)
- [x] Improved installation instructions (especially mac)
- [x] improved README install instructions with links to the latest doc
- [x] added cookbook section on config file
- [x] improved top-level `--help` text
- [x] improved doc makefile (make clean && make preview)

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy vpype vpype_cli tests` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
