### PR TITLE
Added sorting by attribute to `read` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ New features and improvements:
   * The new `pens` command can apply a predefined or custom scheme on multiple layers at once. Two schemes, `rgb` and `cmyk`, are included and others may be defined in the configuration file.
   * The `show` and `write` commands were updated to take into account these new layer properties.
 
+* The `read` command can now optionally sort geometries by attributes (e.g. stroke color, stroke width, etc.) instead of by SVG layer (#378)
+
 * The `read` and `write` commands now preserve a sub-set of SVG attributes (experimental) (#359)
   
   The `read` command now seeks for SVG attributes (e.g. `stroke-dasharray`) which are shared by all geometries in each layer. When found, such attributes are saved as layer properties (with their name prefixed with `svg:`, e.g. `svg:stroke-dasharray`). The `write` command can optionally restore these attributes in the output SVG (using the `--restore-attribs`), thereby maintaining some of the visual aspects of the original SVG (e.g. dashed lines).
@@ -37,6 +39,8 @@ New features and improvements:
 
 API changes:
 * `vpype.Document` and `vpype.LineCollection` have additional members to manage properties through the `vpype._MetadataMixin` mix-in class (#359)
+* Added `vpype.read_svg_by_attribute()` to read SVG while sorting geometries by arbitrary attributes (#378)
+* Added an argument to `vpype_cli.execute()` to pass global option such as `--verbose` (#378)
 
 Other changes:
 * Renamed the bundled config file to `vpype_config.toml` (#359)

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -50,6 +50,27 @@ This command will :ref:`cmd_read` a SVG file, add a single-line :ref:`cmd_frame`
   $ vpype read input.svg frame --offset 5cm write output.svg
 
 
+
+Preserve color (or other attributes) when reading SVG
+=====================================================
+
+By default, the :ref:`cmd_read` command sorts geometries into layers based on the input SVG's top-level groups, akin to Inkscape's layers. Stroke color is preserved *only* if it is identical for every geometries within a layer.
+
+When preserving the color is desirable, the :ref:`cmd_read` command can sort geometries by colors instead of by top-level groups. This is achieved by using the :option:`--attr <read --attr>` option::
+
+  $ vpype read --attr stroke input.svg [...]
+
+Here, we tell the :ref:`cmd_read` command to sort geometry by ``stroke``, which is the SVG attribute that defines the color of an element. As a result, a layer will be created for each different color encountered in the input SVG file.
+
+The same applies for any SVG attributes, even those not explicitly supported by *vpype*. For example, ``--attr stroke-width`` will sort layers by stroke width and ``--attr stroke-dasharray`` by type of stroke dash pattern.
+
+Multiple attributes can even be provided::
+
+  $ vpype read --attr stroke --attr stroke-width input.svg [...]
+
+In this case, a layer will be created for each unique combination of color and stroke width.
+
+
 Make a previsualisation SVG
 ===========================
 

--- a/tests/data/test_svg/misc/multilayer_by_attributes.svg
+++ b/tests/data/test_svg/misc/multilayer_by_attributes.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" baseProfile="tiny" height="15.875cm" version="1.2" viewBox="0 0 600.0 600.0" width="15.875cm" stroke-width="4">
+  <metadata>
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:source>vpype rect 10 10 200 200 rect -l 2 400 400 200 300 write -p 600x600 tests/data/test_svg/benchmark/multilayer.svg
+</dc:source>
+        <dc:date>2020-11-24T15:32:35.445811</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs/>
+  <line stroke="#906" x1="300" y1="20" x2="420" y2="35" stroke-width="1"/>
+  <g fill="none" id="layer1" inkscape:groupmode="layer" inkscape:label="3" stroke="#00f" style="display:inline">
+    <polygon points="10.0,10.0 10.0,210.0 210.0,210.0 210.0,10.0"/>
+  </g>
+  <g fill="none" id="layer2" inkscape:groupmode="layer" inkscape:label="2" stroke="#080" style="display:inline">
+    <polygon points="400.0,400.0 400.0,700.0 600.0,700.0 600.0,400.0" stroke="#00f"/>
+    <g transform="translate(-50, -50) rotate(35, 400, 200)" stroke="#906">
+      <polygon points="400.0,400.0 400.0,700.0 600.0,700.0 600.0,400.0"/>
+    </g>
+  </g>
+</svg>

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -35,6 +35,7 @@ MINIMAL_COMMANDS = [
     Command("ellipse 0 0 2 4"),
     Command(f"read '{EXAMPLE_SVG}'", preserves_metadata=False),
     Command(f"read -m '{EXAMPLE_SVG}'", preserves_metadata=False),
+    Command(f"read -a stroke '{EXAMPLE_SVG}'", preserves_metadata=False),
     Command("write -f svg -"),
     Command("write -f hpgl -d hp7475a -p a4 -"),
     Command("rotate 0"),

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import vpype as vp
+import vpype_cli
 from vpype_cli import DebugData, cli
 
 from .utils import TEST_FILE_DIRECTORY
@@ -383,3 +384,21 @@ def test_read_by_attribute():
     assert len(doc.layers) == 3
     assert _prop_set(doc, "vp:color") == {vp.Color("#906"), vp.Color("#00f")}
     assert _prop_set(doc, "vp:pen_width") == pytest.approx({1, 4})
+
+
+def test_read_layer_assumes_single_layer(runner, caplog):
+    test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer.svg"
+    doc = vpype_cli.execute(f"read --layer 2 '{test_file}'", global_opt="-v")
+
+    assert "assuming single-layer mode" in caplog.text
+    assert len(doc.layers) == 1
+    assert 2 in doc.layers
+
+
+def test_read_single_layer_attr_warning(runner, caplog):
+    test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer_by_attributes.svg"
+    doc = vpype_cli.execute(f"read -m -a stroke '{test_file}'")
+
+    assert "`--attr` is ignored in single-layer mode" in caplog.text
+    assert len(doc.layers) == 1
+    assert 1 in doc.layers

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -2,6 +2,7 @@
 import difflib
 import os
 import re
+from typing import Set
 
 import numpy as np
 import pytest
@@ -367,3 +368,18 @@ layer 2 property vp:name: (str) my layer 2
 layer 3 property vp:name: (str) my layer 3
 """
     )
+
+
+def test_read_by_attribute():
+    def _prop_set(document: vp.Document, prop: str) -> Set:
+        return {layer.property(prop) for layer in document.layers.values()}
+
+    file = TEST_FILE_DIRECTORY / "misc" / "multilayer_by_attributes.svg"
+    doc = vp.read_svg_by_attributes(str(file), ["stroke"], 0.1)
+    assert len(doc.layers) == 2
+    assert _prop_set(doc, "vp:color") == {vp.Color("#906"), vp.Color("#00f")}
+
+    doc = vp.read_svg_by_attributes(str(file), ["stroke", "stroke-width"], 0.1)
+    assert len(doc.layers) == 3
+    assert _prop_set(doc, "vp:color") == {vp.Color("#906"), vp.Color("#00f")}
+    assert _prop_set(doc, "vp:pen_width") == pytest.approx({1, 4})

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -346,7 +346,9 @@ def preprocess_argument_list(args: List[str], cwd: Union[str, None] = None) -> L
     return result
 
 
-def execute(pipeline: str, document: Optional[vp.Document] = None) -> vp.Document:
+def execute(
+    pipeline: str, document: Optional[vp.Document] = None, global_opt: str = ""
+) -> vp.Document:
     """Execute a vpype pipeline.
 
     This function serves as a Python API to vpype's pipeline. It can be used from a regular
@@ -373,6 +375,7 @@ def execute(pipeline: str, document: Optional[vp.Document] = None) -> vp.Documen
     Args:
         pipeline: vpype pipeline as would be used with ``vpype`` CLI
         document: if provided, is perloaded in the pipeline before the first command executes
+        global_opt: global CLI option (e.g. "--verbose")
 
     Returns:
         pipeline's content after the last command executes
@@ -394,6 +397,8 @@ def execute(pipeline: str, document: Optional[vp.Document] = None) -> vp.Documen
         out_doc.extend(doc)
         return doc
 
-    args = ("vsketchinput " if document else "") + pipeline + " vsketchoutput"
+    args = " ".join(
+        [global_opt, ("vsketchinput " if document else ""), pipeline, "vsketchoutput"]
+    )
     cli.main(prog_name="vpype", args=shlex.split(args), standalone_mode=False)
     return out_doc


### PR DESCRIPTION
#### Description

The `read` command can now sort geometries by layers based on attribute. For example, this sorts geometries by stroke color:
```
vpype read --attr stroke input.svg ...
```

Multiple attributes can be provided, in which case one layer will be created for each unique combination of attribute:
```
vpype read --attr stroke --attr stroke-width input.svg ...
```

Fixes #35 

Other changes:
- added vpype.read_svg_by_attribute() to read SVG sorting geometries by attribute(s)
- multiple refactoring in vpype/io.py
- `read` now use single-layer mode when `--layer` is used, even if `--single-layer` is not used (fixes #36)


#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
