### PR TITLE
Changed "layer does not exist" to info (was warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ New features and improvements:
   * When `--prob` is not used, the `lswap` command now swaps the layer properties as well.
   * These behaviors can be disabled with the `--no-prop` option.
 
-* Providing a non-existent layer ID to any `--layer` parameter now generates a warning (#359)
+* Providing a non-existent layer ID to any `--layer` parameter now generates a note (visible with `--verbose`) (#359, #382)
 
 API changes:
 * `vpype.Document` and `vpype.LineCollection` have additional members to manage properties through the `vpype._MetadataMixin` mix-in class (#359)

--- a/vpype/layers.py
+++ b/vpype/layers.py
@@ -52,7 +52,7 @@ def multiple_to_layer_ids(
             if document.exists(lid):
                 lids.append(lid)
             else:
-                logging.warning(f"layer {lid} does not exist")
+                logging.info(f"layer {lid} does not exist")
         return lids
     else:
         return []


### PR DESCRIPTION
#### Description

There are way to many use cases where layers might not exists. Warning was too verbose.


#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
