### PR TITLE
Add `--keep` option to the `ldelete` command (to delete all layers but those specified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ New features and improvements:
   * When `--prob` is not used, the `lswap` command now swaps the layer properties as well.
   * These behaviors can be disabled with the `--no-prop` option.
 
+* Added `--keep` option to the `ldelete` command (to delete all layers but those specified) (#383)
 * Providing a non-existent layer ID to any `--layer` parameter now generates a note (visible with `--verbose`) (#359, #382)
 
 API changes:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -133,6 +133,25 @@ def test_ldelete(big_doc):
     assert len(doc.layers) == 0
 
 
+@pytest.mark.parametrize(
+    ["cmd", "resulting_layers"],
+    [
+        ("random random -l2 ldelete 1", {2}),
+        ("random random -l2 ldelete --keep 1", {1}),
+        ("random random -l2 ldelete --keep 3", {}),
+        ("random random -l2 random -l3 ldelete --keep 1", {1}),
+        ("random random -l2 random -l3 ldelete --keep 1,3", {1, 3}),
+        ("random random -l2 random -l3 ldelete --keep 1,4,5", {1}),
+        ("random random -l2 random -l3 ldelete 1", {2, 3}),
+        ("random random -l2 random -l3 ldelete 1,3", {2}),
+        ("random random -l2 random -l3 ldelete 1,4,5", {2, 3}),
+    ],
+)
+def test_ldelete_keep(cmd, resulting_layers):
+    doc = execute(cmd)
+    assert doc.layers.keys() == set(resulting_layers)
+
+
 def test_ldelete_prob_one(big_doc):
     doc = execute("ldelete --prob 1. 1", big_doc)
 

--- a/vpype_cli/layerops.py
+++ b/vpype_cli/layerops.py
@@ -158,23 +158,32 @@ def lmove(document, sources, dest, prob: Optional[float], no_prop: bool):
 @cli.command(group="Layers")
 @click.argument("layers", type=vp.LayerType(accept_multiple=True))
 @click.option(
+    "-k", "--keep", is_flag=True, help="Specified layers must be kept instead of deleted."
+)
+@click.option(
     "-p",
     "--prob",
     type=click.FloatRange(0.0, 1.0),
     help="Path deletion probability (default: 1.0).",
 )
 @vp.global_processor
-def ldelete(document: vp.Document, layers, prob: Optional[float]) -> vp.Document:
+def ldelete(document: vp.Document, layers, keep: bool, prob: Optional[float]) -> vp.Document:
     """Delete one or more layers.
 
     LAYERS can be a single layer ID, the string 'all' (to delete all layers), or a
     coma-separated, whitespace-free list of layer IDs.
+
+    If the `--keep` option is used, the specified layers are kept and, instead, all other
+    layers deleted.
 
     The `--prob` option controls the probability with which each path is deleted. With a value
     lower than 1.0, some paths will not be deleted.
     """
 
     lids = set(vp.multiple_to_layer_ids(layers, document))
+
+    if keep:
+        lids = document.layers.keys() - lids
 
     for lid in lids:
         if prob is not None:


### PR DESCRIPTION
#### Description

Useful e.g when loading a single layer from a SVG file:
```
vpype read input.svg ldelete --keep 2
```

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
