### PR TITLE
Change system property convention to `vp_` instead of `vp:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ New features and improvements:
 
 * The `read` and `write` commands now preserve a sub-set of SVG attributes (experimental) (#359)
   
-  The `read` command now seeks for SVG attributes (e.g. `stroke-dasharray`) which are shared by all geometries in each layer. When found, such attributes are saved as layer properties (with their name prefixed with `svg:`, e.g. `svg:stroke-dasharray`). The `write` command can optionally restore these attributes in the output SVG (using the `--restore-attribs`), thereby maintaining some of the visual aspects of the original SVG (e.g. dashed lines).
+  The `read` command now seeks for SVG attributes (e.g. `stroke-dasharray`) which are shared by all geometries in each layer. When found, such attributes are saved as layer properties (with their name prefixed with `svg_`, e.g. `svg_stroke-dasharray`). The `write` command can optionally restore these attributes in the output SVG (using the `--restore-attribs`), thereby maintaining some of the visual aspects of the original SVG (e.g. dashed lines).
 
 * Introduced new commands for low-level inspection and modification of metadata (#359)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ New features and improvements:
   
   This feature is intended as a generic mechanism whereby a set of properties may be attached to specific layers (layer property) or all of them (global property). Properties are identified by a name and may be of arbitrary type (e.g. integer, floating point, color, etc.). This new infrastructure is used by several of the features introduced in this release, paves the way for future features, and further empowers plug-in writers. See the [documentation](https://vpype.readthedocs.io/en/latest/metadata) for more background information on metadata.
 
-* Layer color, pen width, and name are now customizable (#359, #376)
+* Layer color, pen width, and name are now customizable (#359, #376, #389)
   * The `read` commands now sets layer color, pen width, and name based on the input SVG if possible.
   * The new `color`, `penwdith`, and `name` commands can be used to modify layer color, pen width, and name.
   * The new `pens` command can apply a predefined or custom scheme on multiple layers at once. Two schemes, `rgb` and `cmyk`, are included and others may be defined in the configuration file.
   * The `show` and `write` commands were updated to take into account these new layer properties.
 
-* The `read` command can now optionally sort geometries by attributes (e.g. stroke color, stroke width, etc.) instead of by SVG layer (#378)
+* The `read` command can now optionally sort geometries by attributes (e.g. stroke color, stroke width, etc.) instead of by SVG layer (#378, #389)
 
-* The `read` and `write` commands now preserve a sub-set of SVG attributes (experimental) (#359)
+* The `read` and `write` commands now preserve a sub-set of SVG attributes (experimental) (#359, #389)
   
   The `read` command now seeks for SVG attributes (e.g. `stroke-dasharray`) which are shared by all geometries in each layer. When found, such attributes are saved as layer properties (with their name prefixed with `svg_`, e.g. `svg_stroke-dasharray`). The `write` command can optionally restore these attributes in the output SVG (using the `--restore-attribs`), thereby maintaining some of the visual aspects of the original SVG (e.g. dashed lines).
 

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -167,12 +167,12 @@ Metadata is data which provides information about other data. In the case of *vp
 System properties
 -----------------
 
-Some properties are referred to as *system properties*. Their name is prefixed with ``vp:`` and they are widely used throughout *vpype*. Currently, the following system properties are defined:
+Some properties are referred to as *system properties*. Their name is prefixed with ``vp_`` and they are widely used throughout *vpype*. Currently, the following system properties are defined:
 
-  * ``vp:color``: the color of a layer (layer property)
-  * ``vp:pen_width``: the pen width of a layer (layer property)
-  * ``vp:name``: the name of a layer (layer property)
-  * ``vp:page_size``: the page size (global property)
+  * ``vp_color``: the color of a layer (layer property)
+  * ``vp_pen_width``: the pen width of a layer (layer property)
+  * ``vp_name``: the name of a layer (layer property)
+  * ``vp_page_size``: the page size (global property)
 
 Many commands acts on these properties. For example, the :ref:`cmd_read` command sets these properties according to the imported SVG file's content. The :ref:`cmd_color`, :ref:`cmd_penwidth`, :ref:`cmd_name`, and :ref:`cmd_pens` commands can set these properties to arbitrary values. In particular, the :ref:`cmd_pens` commands can apply a predefined set of values on multiple layers at once, for example to apply a CMYK color scheme (see :ref:`faq_custom_pen_config` for more information). The page size global property is set by the :ref:`cmd_pagesize` and :ref:`cmd_layout` commands.
 
@@ -180,11 +180,11 @@ Many commands acts on these properties. For example, the :ref:`cmd_read` command
 SVG attributes properties
 -------------------------
 
-The :ref:`cmd_read` command identifies SVG attributes common to all geometries in a given layer and store their value as layer property with a ``svg:`` prefix. For example, if all geometries in a given layer share a ``stroke-dasharray="3 1"`` SVG attribute (either because it is set at the level of the group element, or because it is set in every single geometry elements), a property named ``svg:stroke-dasharray`` with a value of ``"3 1"`` is added to the layer.
+The :ref:`cmd_read` command identifies SVG attributes common to all geometries in a given layer and store their value as layer property with a ``svg_`` prefix. For example, if all geometries in a given layer share a ``stroke-dasharray="3 1"`` SVG attribute (either because it is set at the level of the group element, or because it is set in every single geometry elements), a property named ``svg_stroke-dasharray`` with a value of ``"3 1"`` is added to the layer.
 
 These properties are set for informational and extension purposes, and are mostly ignored by *vpype* commands. One exception is the :ref:`cmd_write` command, which can optionally restore these attributes in the exported SVG file.
 
-An example of future extension could be a plug-in which detects the ``svg:stroke-dasharray`` property and turns the corresponding layer's lines into their dashed equivalent. Another example would be a plug-in looking for a ``svg:fill`` property and adding the corresponding hatching patterns to reproduce the filled area.
+An example of future extension could be a plug-in which detects the ``svg_stroke-dasharray`` property and turns the corresponding layer's lines into their dashed equivalent. Another example would be a plug-in looking for a ``svg_fill`` property and adding the corresponding hatching patterns to reproduce the filled area.
 
 
 Interacting with properties

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -596,34 +596,34 @@ def test_text_command_empty():
         (
             "pens rgb proplist -l all",
             "listing 2 properties for layer 1\n"
-            "  vp:color: (color) #ff0000\n"
-            "  vp:name: (str) red\n"
+            "  vp_color: (color) #ff0000\n"
+            "  vp_name: (str) red\n"
             "listing 2 properties for layer 2\n"
-            "  vp:color: (color) #008000\n"
-            "  vp:name: (str) green\n"
+            "  vp_color: (color) #008000\n"
+            "  vp_name: (str) green\n"
             "listing 2 properties for layer 3\n"
-            "  vp:color: (color) #0000ff\n"
-            "  vp:name: (str) blue",
+            "  vp_color: (color) #0000ff\n"
+            "  vp_name: (str) blue",
         ),
         (
-            "pens rgb propdel -l1 vp:color proplist -l all",
-            "listing 1 properties for layer 1\n  vp:name: (str) red\n"
+            "pens rgb propdel -l1 vp_color proplist -l all",
+            "listing 1 properties for layer 1\n  vp_name: (str) red\n"
             "listing 2 properties for layer 2\n"
-            "  vp:color: (color) #008000\n"
-            "  vp:name: (str) green\n"
+            "  vp_color: (color) #008000\n"
+            "  vp_name: (str) green\n"
             "listing 2 properties for layer 3\n"
-            "  vp:color: (color) #0000ff\n"
-            "  vp:name: (str) blue",
+            "  vp_color: (color) #0000ff\n"
+            "  vp_name: (str) blue",
         ),
         (
-            "pens rgb propdel -l all vp:color proplist -l all",
-            "listing 1 properties for layer 1\n  vp:name: (str) red\n"
-            "listing 1 properties for layer 2\n  vp:name: (str) green\n"
-            "listing 1 properties for layer 3\n  vp:name: (str) blue",
+            "pens rgb propdel -l all vp_color proplist -l all",
+            "listing 1 properties for layer 1\n  vp_name: (str) red\n"
+            "listing 1 properties for layer 2\n  vp_name: (str) green\n"
+            "listing 1 properties for layer 3\n  vp_name: (str) blue",
         ),
         (
-            "pens rgb propdel -l all vp:color proplist -l 2",
-            "listing 1 properties for layer 2\n  vp:name: (str) green",
+            "pens rgb propdel -l all vp_color proplist -l 2",
+            "listing 1 properties for layer 2\n  vp_name: (str) green",
         ),
         (
             "pens rgb propclear -l all proplist",
@@ -633,10 +633,10 @@ def test_text_command_empty():
         ),
         (
             "pagesize 400x1200 proplist -g",
-            "listing 1 global properties\n  vp:page_size: (tuple) (400.0, 1200.0)",
+            "listing 1 global properties\n  vp_page_size: (tuple) (400.0, 1200.0)",
         ),
         (
-            "pagesize 400x1200 propdel -g vp:page_size proplist -g",
+            "pagesize 400x1200 propdel -g vp_page_size proplist -g",
             "listing 0 global properties",
         ),
         ("propset -g -t int prop 10 propget -g prop", "global property prop: (int) 10"),

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -386,7 +386,7 @@ def test_read_by_attribute():
     assert _prop_set(doc, "vp_pen_width") == pytest.approx({1, 4})
 
 
-def test_read_layer_assumes_single_layer(runner, caplog):
+def test_read_layer_assumes_single_layer(caplog):
     test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer.svg"
     doc = vpype_cli.execute(f"read --layer 2 '{test_file}'", global_opt="-v")
 
@@ -395,10 +395,32 @@ def test_read_layer_assumes_single_layer(runner, caplog):
     assert 2 in doc.layers
 
 
-def test_read_single_layer_attr_warning(runner, caplog):
+def test_read_single_layer_attr_warning(caplog):
     test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer_by_attributes.svg"
     doc = vpype_cli.execute(f"read -m -a stroke '{test_file}'")
 
     assert "`--attr` is ignored in single-layer mode" in caplog.text
     assert len(doc.layers) == 1
     assert 1 in doc.layers
+
+
+def test_write_svg_svg_props(tmp_path):
+    file_path = tmp_path / "file.svg"
+
+    vpype_cli.execute(
+        f"line 0 0 10 10 layout a5 propset -l1 svg_stroke-dasharray '1 2' "
+        f"write -r -f svg {file_path}"
+    )
+    assert 'stroke-dasharray="1 2"' in file_path.read_text()
+
+    vpype_cli.execute(
+        f"line 0 0 10 10 layout a5 propset -g svg_inkscape_version '1.1.0' "
+        f"write -r -f svg {file_path}"
+    )
+    assert 'inkscape:version="1.1.0"' in file_path.read_text()
+
+    vpype_cli.execute(
+        f"line 0 0 10 10 layout a5 propset -g svg_unknown_version '1.1.0' "
+        f"write -r -f svg {file_path}"
+    )
+    assert 'unknown:version="1.1.0"' not in file_path.read_text()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -404,23 +404,22 @@ def test_read_single_layer_attr_warning(caplog):
     assert 1 in doc.layers
 
 
-def test_write_svg_svg_props(tmp_path):
-    file_path = tmp_path / "file.svg"
-
+def test_write_svg_svg_props(capsys):
     vpype_cli.execute(
-        f"line 0 0 10 10 layout a5 propset -l1 svg_stroke-dasharray '1 2' "
-        f"write -r -f svg {file_path}"
+        "line 0 0 10 10 layout a5 propset -l1 svg_stroke-dasharray '1 2' write -r -f svg -"
     )
-    assert 'stroke-dasharray="1 2"' in file_path.read_text()
+    assert 'stroke-dasharray="1 2"' in capsys.readouterr().out
 
-    vpype_cli.execute(
-        f"line 0 0 10 10 layout a5 propset -g svg_inkscape_version '1.1.0' "
-        f"write -r -f svg {file_path}"
-    )
-    assert 'inkscape:version="1.1.0"' in file_path.read_text()
 
+def test_write_svg_svg_props_namespace(capsys):
     vpype_cli.execute(
-        f"line 0 0 10 10 layout a5 propset -g svg_unknown_version '1.1.0' "
-        f"write -r -f svg {file_path}"
+        "line 0 0 10 10 layout a5 propset -g svg_inkscape_version '1.1.0' write -r -f svg -"
     )
-    assert 'unknown:version="1.1.0"' not in file_path.read_text()
+    assert 'inkscape:version="1.1.0"' in capsys.readouterr().out
+
+
+def test_write_svg_svg_props_unknown_namespace(capsys):
+    vpype_cli.execute(
+        "line 0 0 10 10 layout a5 propset -g svg_unknown_version '1.1.0' write -r -f svg -"
+    )
+    assert 'unknown:version="1.1.0"' not in capsys.readouterr().out

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -180,21 +180,21 @@ def test_read_stdin(runner):
             """<?xml version="1.0"?><svg>
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {1: {"svg:fill": "red"}},
+            {1: {"svg_fill": "red"}},
             id="lone_line",
         ),
         pytest.param(
             """<?xml version="1.0"?><svg font="#f00">
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {0: {"svg:font": "#f00"}, 1: {"svg:fill": "red"}},
+            {0: {"svg_font": "#f00"}, 1: {"svg_fill": "red"}},
             id="lone_line_svg_attrib",
         ),
         pytest.param(
             """<?xml version="1.0"?><svg fill="blue">
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {1: {"svg:fill": "red"}},
+            {1: {"svg_fill": "red"}},
             id="lone_line_svg_attrib_conflict",
         ),
         pytest.param(
@@ -202,7 +202,7 @@ def test_read_stdin(runner):
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 <line x1="0" y1="0" x2="10" y2="10" fill="green" />
             </svg>""",
-            {1: {"svg:fill": None}},
+            {1: {"svg_fill": None}},
             id="two_line_inconsistent",
         ),
         pytest.param(
@@ -212,7 +212,7 @@ def test_read_stdin(runner):
                     <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 </g>
             </svg>""",
-            {1: {"svg:fill": "red"}},
+            {1: {"svg_fill": "red"}},
             id="group_1_with_lone_line_svg_attrib_conflict",
         ),
         pytest.param(
@@ -221,7 +221,7 @@ def test_read_stdin(runner):
                     <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 </g>
             </svg>""",
-            {1: {"svg:fill": "red"}},
+            {1: {"svg_fill": "red"}},
             id="group_1_svg_attrib_conflict",
         ),
         pytest.param(
@@ -231,7 +231,7 @@ def test_read_stdin(runner):
                     <line x1="0" y1="0" x2="10" y2="10" fill="green" />
                 </g>
             </svg>""",
-            {1: {"svg:fill": None}},
+            {1: {"svg_fill": None}},
             id="inconsistent_group1",
         ),
         pytest.param(
@@ -249,7 +249,7 @@ def test_read_stdin(runner):
                     <circle cx="0" cy="0" r="10" fill="#666" />
                 </g>
             </svg>""",
-            {0: {"svg:fill": "blue"}, 1: {"svg:fill": "red"}, 2: {}, 3: {"svg:fill": "#666"}},
+            {0: {"svg_fill": "blue"}, 1: {"svg_fill": "red"}, 2: {}, 3: {"svg_fill": "#666"}},
             id="multi_layer",
         ),
     ],
@@ -284,21 +284,21 @@ def test_read_multilayer_metadata(tmp_path, svg, expected_metadata):
             """<?xml version="1.0"?><svg>
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {"svg:fill": "red"},
+            {"svg_fill": "red"},
             id="lone_line",
         ),
         pytest.param(
             """<?xml version="1.0"?><svg stroke="#f00">
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {"svg:fill": "red", "svg:stroke": "#f00"},
+            {"svg_fill": "red", "svg_stroke": "#f00"},
             id="lone_line_svg_attrib",
         ),
         pytest.param(
             """<?xml version="1.0"?><svg fill="blue">
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
             </svg>""",
-            {"svg:fill": "red"},
+            {"svg_fill": "red"},
             id="lone_line_svg_attrib_conflict",
         ),
         pytest.param(
@@ -306,7 +306,7 @@ def test_read_multilayer_metadata(tmp_path, svg, expected_metadata):
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 <line x1="0" y1="0" x2="10" y2="10" fill="green" />
             </svg>""",
-            {"svg:fill": None},
+            {"svg_fill": None},
             id="two_line_inconsistent",
         ),
         pytest.param(
@@ -316,7 +316,7 @@ def test_read_multilayer_metadata(tmp_path, svg, expected_metadata):
                     <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 </g>
             </svg>""",
-            {"svg:fill": "red"},
+            {"svg_fill": "red"},
             id="group_1_with_lone_line_svg_attrib_conflict",
         ),
         pytest.param(
@@ -325,7 +325,7 @@ def test_read_multilayer_metadata(tmp_path, svg, expected_metadata):
                     <line x1="0" y1="0" x2="10" y2="10" fill="red" />
                 </g>
             </svg>""",
-            {"svg:fill": "red"},
+            {"svg_fill": "red"},
             id="group_1_svg_attrib_conflict",
         ),
         pytest.param(
@@ -335,7 +335,7 @@ def test_read_multilayer_metadata(tmp_path, svg, expected_metadata):
                     <line x1="0" y1="0" x2="10" y2="10" fill="green" />
                 </g>
             </svg>""",
-            {"svg:fill": None},
+            {"svg_fill": None},
             id="inconsistent_group1",
         ),
     ],
@@ -364,9 +364,9 @@ def test_read_layer_name(runner):
     assert res.exit_code == 0
     assert (
         res.stdout
-        == """layer 1 property vp:name: (str) my layer 1
-layer 2 property vp:name: (str) my layer 2
-layer 3 property vp:name: (str) my layer 3
+        == """layer 1 property vp_name: (str) my layer 1
+layer 2 property vp_name: (str) my layer 2
+layer 3 property vp_name: (str) my layer 3
 """
     )
 
@@ -378,12 +378,12 @@ def test_read_by_attribute():
     file = TEST_FILE_DIRECTORY / "misc" / "multilayer_by_attributes.svg"
     doc = vp.read_svg_by_attributes(str(file), ["stroke"], 0.1)
     assert len(doc.layers) == 2
-    assert _prop_set(doc, "vp:color") == {vp.Color("#906"), vp.Color("#00f")}
+    assert _prop_set(doc, "vp_color") == {vp.Color("#906"), vp.Color("#00f")}
 
     doc = vp.read_svg_by_attributes(str(file), ["stroke", "stroke-width"], 0.1)
     assert len(doc.layers) == 3
-    assert _prop_set(doc, "vp:color") == {vp.Color("#906"), vp.Color("#00f")}
-    assert _prop_set(doc, "vp:pen_width") == pytest.approx({1, 4})
+    assert _prop_set(doc, "vp_color") == {vp.Color("#906"), vp.Color("#00f")}
+    assert _prop_set(doc, "vp_pen_width") == pytest.approx({1, 4})
 
 
 def test_read_layer_assumes_single_layer(runner, caplog):

--- a/vpype/metadata.py
+++ b/vpype/metadata.py
@@ -63,12 +63,13 @@ class Color:
 
 
 # layer metadata field names
-METADATA_FIELD_NAME = "vp:name"
-METADATA_FIELD_COLOR = "vp:color"
-METADATA_FIELD_PEN_WIDTH = "vp:pen_width"
+METADATA_FIELD_NAME = "vp_name"
+METADATA_FIELD_COLOR = "vp_color"
+METADATA_FIELD_PEN_WIDTH = "vp_pen_width"
 
 # global metadata field names
-METADATA_FIELD_PAGE_SIZE = "vp:page_size"
+METADATA_FIELD_SVG_NAMESPACES = "vp_svg_ns"
+METADATA_FIELD_PAGE_SIZE = "vp_page_size"
 
 METADATA_SYSTEM_FIELD_TYPES = {
     METADATA_FIELD_NAME: str,

--- a/vpype_cli/metadata.py
+++ b/vpype_cli/metadata.py
@@ -100,7 +100,7 @@ def propset(
         Set the layer property of type `float` (this is equivalent to using the `penwidth`
         command:
 
-            vpype [...] propset --layer 1 --type float vp:pen_width 0.5mm [...]
+            vpype [...] propset --layer 1 --type float vp_pen_width 0.5mm [...]
 
         Set a layer property of type `color`:
 
@@ -179,9 +179,9 @@ def propget(
 
     Examples:
 
-        Print the value of property `vp:color` for all layers:
+        Print the value of property `vp_color` for all layers:
 
-            vpype [...] pens cmyk propget --layer all vp:color [...]
+            vpype [...] pens cmyk propget --layer all vp_color [...]
     """
     global_flag, layer = _check_scope(global_flag, layer)
 
@@ -215,7 +215,7 @@ def propdel(
 
         Remove a property from a layer:
 
-            vpype [...] pens cmyk propdel --layer 1 vp:name [...]
+            vpype [...] pens cmyk propdel --layer 1 vp_name [...]
     """
     global_flag, layer = _check_scope(global_flag, layer)
 

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -147,7 +147,7 @@ of appearance.
     When importing the SVG, the `read` commands attempts to extract the SVG attributes that
     are common to all paths within a layer. The "stroke", "stroke-width" and "inkscape:label"
     attributes are used to set the layer color, pen width and, respectively, name. The other
-    attributes (e.g. "stroke-dasharray", etc.) are stored as layer properties with a "svg_"
+    attributes (e.g. "stroke-dasharray", etc.) are stored as layer properties with a `svg_`
     prefix. These properties are ignored by vpype but may be used by plug-ins. Also, the
     `write` command can optionally restore them in the exported SVG.
 

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -93,7 +93,7 @@ def read(
     FILE may be a file path path or a dash (-) to read from the standard input instead.
 
     By default, the `read` command attempts to preserve the layer structure of the SVG. In this
-    context, top-level groups (<svg:g>) are each considered a layer. If any, all non-group,
+    context, top-level groups (<g>) are each considered a layer. If any, all non-group,
     top-level SVG elements are imported into layer 1.
 
     The following logic is used to determine in which layer each SVG top-level group is
@@ -147,7 +147,7 @@ of appearance.
     When importing the SVG, the `read` commands attempts to extract the SVG attributes that
     are common to all paths within a layer. The "stroke", "stroke-width" and "inkscape:label"
     attributes are used to set the layer color, pen width and, respectively, name. The other
-    attributes (e.g. "stroke-dasharray", etc.) are stored as layer properties with a "svg:"
+    attributes (e.g. "stroke-dasharray", etc.) are stored as layer properties with a "svg_"
     prefix. These properties are ignored by vpype but may be used by plug-ins. Also, the
     `write` command can optionally restore them in the exported SVG.
 

--- a/vpype_viewer/engine.py
+++ b/vpype_viewer/engine.py
@@ -439,7 +439,9 @@ class Engine:
                         )
                     )
                 elif self.view_mode == ViewMode.PREVIEW:
-                    pen_width = lc.metadata.get("vp:pen_width", self._default_pen_width)
+                    pen_width = lc.metadata.get(
+                        vp.METADATA_FIELD_PEN_WIDTH, self._default_pen_width
+                    )
                     self._layer_painters[layer_id].append(
                         LineCollectionPreviewPainter(
                             self._ctx,


### PR DESCRIPTION
#### Description

This change will make (most) property name compatible with the `str.format()` mini-language, which will be used throughout vpype_cli in the future.

Also:
- Improved namespace detection regex
- Fixed overwriting of inkscape layer name in write_svg()

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
