### PR TITLE
Fix property substitution on empty layer

### DIFF
--- a/tests/test_property_substitution.py
+++ b/tests/test_property_substitution.py
@@ -50,3 +50,9 @@ def test_property_substitution_invalid(runner):
 def test_property_substitution_int():
     doc = vpype_cli.execute("propset -g -t int num 2 repeat 2 random -l new end")
     assert {1, 2} == doc.layers.keys()
+
+
+def test_property_substitution_empty_layer():
+    # property substitution should work even if the layer is empty
+    doc = vpype_cli.execute("pens rgb text {vp_name}")
+    assert len(doc.layers[1]) > 0

--- a/vpype_cli/state.py
+++ b/vpype_cli/state.py
@@ -20,9 +20,9 @@ class _SubstitutionHelper:
         self.layer = layer
 
     def __getitem__(self, item):
-        if self.layer and self.layer.property_exists(item):
+        if self.layer is not None and self.layer.property_exists(item):
             return self.layer.property(item)
-        elif self.document and self.document.property_exists(item):
+        elif self.document is not None and self.document.property_exists(item):
             return self.document.property(item)
         else:
             raise click.BadParameter(f"Cannot substitute {{{item}}}: property not found")


### PR DESCRIPTION
#### Description

Fix property substitution on empty layer

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
