### PR TITLE
Feature: `pagerotate` command to rotate the page (geometries included) b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ New features and improvements:
   
   Previously, the first generator command of the pipeline would default to create a new layer if the `--layer` option was not provided. This could lead to unexpected behaviour in several situation. The target layer is now layer 1. For subsequent generators, the existing behaviour of using the previous generator target layer as default remains.   
 
-* Added `pagerotate` command, to rotate the page layout (including geometries) by 90 degrees (#XXX)
+* Added `pagerotate` command, to rotate the page layout (including geometries) by 90 degrees (#404)
 * Added `--keep` option to the `ldelete` command (to delete all layers but those specified) (#383)
 * Providing a non-existent layer ID to any `--layer` parameter now generates a note (visible with `--verbose`) (#359, #382)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ New features and improvements:
   
   Previously, the first generator command of the pipeline would default to create a new layer if the `--layer` option was not provided. This could lead to unexpected behaviour in several situation. The target layer is now layer 1. For subsequent generators, the existing behaviour of using the previous generator target layer as default remains.   
 
+* Added `pagerotate` command, to rotate the page layout (including geometries) by 90 degrees (#XXX)
 * Added `--keep` option to the `ldelete` command (to delete all layers but those specified) (#383)
 * Providing a non-existent layer ID to any `--layer` parameter now generates a note (visible with `--verbose`) (#359, #382)
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ and much more.
 
 - Easy and flexible **layout** command for centring and fitting to margin with selectable le horizontal and vertical alignment
   ([`layout`](https://vpype.readthedocs.io/en/latest/reference.html#layout)).
+- **Page rotation** command ([`pagerotate`](https://vpype.readthedocs.io/en/latest/reference.html#pagerotate)).
 - Powerful **transform** commands for scaling, translating, skewing and rotating geometries ([`scale`](https://vpype.readthedocs.io/en/latest/reference.html#scale), [`translate`](https://vpype.readthedocs.io/en/latest/reference.html#translate), [`skew`](https://vpype.readthedocs.io/en/latest/reference.html#skew), [`rotate`](https://vpype.readthedocs.io/en/latest/reference.html#rotate)).
 - Support for **scaling** and **cropping** to arbitrary dimensions ([`scaleto`](https://vpype.readthedocs.io/en/latest/reference.html#scaleto), [`crop`](https://vpype.readthedocs.io/en/latest/reference.html#crop)).
 - Support for **trimming** geometries by an arbitrary amount ([`trim`](https://vpype.readthedocs.io/en/latest/reference.html#trim)).

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -111,6 +111,10 @@ CLI reference
 .. click:: vpype_cli:name
    :prog: name
 
+.. _cmd_pagerotate:
+.. click:: vpype_cli:pagerotate
+   :prog: pagerotate
+
 .. _cmd_pagesize:
 .. click:: vpype_cli:pagesize
    :prog: pagesize

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -98,6 +98,7 @@ MINIMAL_COMMANDS = [
     ),
     Command("eval x=2 eval %y=3 eval z=4% eval %w=5%"),
     Command("forlayer text '%_lid% (%_i%/%_n%): %_name%' end"),
+    Command("pagerotate", keeps_page_size=False),
 ]
 
 # noinspection SpellCheckingInspection
@@ -687,3 +688,17 @@ def test_forlayer_command_property_accessor():
     for i in range(3):
         assert doc.layers[i + 1].property("test") == i
         assert doc.layers[i + 1].property("test2") == i
+
+
+def test_pagerotate():
+    doc = vpype_cli.execute("random pagesize a4 pagerotate")
+    assert doc.page_size == pytest.approx((1122.5196850393702, 793.7007874015749))
+
+    doc = vpype_cli.execute("random pagesize a4 pagerotate -cw")
+    assert doc.page_size == pytest.approx((1122.5196850393702, 793.7007874015749))
+
+
+def test_pagerotate_error(caplog):
+    doc = vpype_cli.execute("random pagerotate")
+    assert doc.page_size is None
+    assert "page size is not defined, page not rotated" in caplog.text

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import List, Optional, Tuple, Union, cast
 
 import click
@@ -606,6 +607,39 @@ def layout(
         v_offset = margin + (size[1] - height - 2 * margin) / 2 - min_y
 
     document.translate(h_offset, v_offset)
+    return document
+
+
+@cli.command(group="Operations")
+@click.option(
+    "--clockwise",
+    "-cw",
+    is_flag=True,
+    help="Rotate clockwise instead of the default counter-clockwise",
+)
+@global_processor
+def pagerotate(document: vp.Document, clockwise: bool):
+    """Rotate the page by 90 degrees.
+
+    This command rotates the page by 90 degrees counter-clockwise. If the `--clockwise` option
+    is passed, it rotates the page clockwise instead.
+
+    Note: if the page size is not defined, an error is printed and the page is not rotated.
+    """
+    page_size = document.page_size
+    if page_size is None:
+        logging.warning("pagerotate: page size is not defined, page not rotated")
+        return document
+    w, h = page_size
+
+    if clockwise:
+        document.rotate(math.pi / 2)
+        document.translate(h, 0)
+    else:
+        document.rotate(-math.pi / 2)
+        document.translate(0, w)
+
+    document.page_size = h, w
     return document
 
 

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -19,6 +19,7 @@ __all__ = (
     "linesimplify",
     "linesort",
     "multipass",
+    "pagerotate",
     "pagesize",
     "reloop",
     "reverse",


### PR DESCRIPTION

#### Description

This PR implements the `page rotate` command to rotate the page (geometries included) by 90 degrees

Fixes #364

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [x] added new command to `reference.rst`
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
