### PR TITLE
Pinned poetry-core to 1.0.8 to enable editable install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ API changes:
 
 Other changes:
 * Renamed the bundled config file to `vpype_config.toml` (#359)
+* Pinned poetry-core to 1.0.8 to enable editable installs (#410)
 * Changed dependencies to dataclasses (instead of attrs) and tomli (instead of toml) (#362)
 * Removed dependency to click-plugin (#388)
 * Improved documentation, in particular the [Fundamentals](https://vpype.readthedocs.io/en/latest/fundamentals.html) and [Cookbook](https://vpype.readthedocs.io/en/latest/cookbook.html) sections (#359, #363, #397)

--- a/poetry.lock
+++ b/poetry.lock
@@ -235,7 +235,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.1"
+version = "4.11.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -246,7 +246,7 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
@@ -898,7 +898,7 @@ test = ["pytest"]
 
 [[package]]
 name = "svgelements"
-version = "1.6.9"
+version = "1.6.10"
 description = "Svg Elements Parsing"
 category = "main"
 optional = false
@@ -992,7 +992,7 @@ docs = ["Sphinx", "sphinx-click", "sphinx-autodoc-typehints", "sphinx-rtd-theme"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, !=3.9.0, <3.10"
-content-hash = "e03af9957e8aae66b123e7c75865a994d87278fad7ab902ee499e78e52232dbc"
+content-hash = "b9e391ecb26daf8ec76520631c5fa233de1f6c04cd8d653f931f79d5e51da528"
 
 [metadata.files]
 alabaster = [
@@ -1162,8 +1162,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.1-py3-none-any.whl", hash = "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"},
-    {file = "importlib_metadata-4.11.1.tar.gz", hash = "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c"},
+    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
+    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -1657,8 +1657,8 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 svgelements = [
-    {file = "svgelements-1.6.9-py2.py3-none-any.whl", hash = "sha256:83c3e53d7ae4cd7f4d7f4e7be29444870507e0d559a7a06160284be9e222c325"},
-    {file = "svgelements-1.6.9.tar.gz", hash = "sha256:355a5cd5f43834cfdfab669298253d17138c76b00feafb53fdbb59000aeb54a7"},
+    {file = "svgelements-1.6.10-py2.py3-none-any.whl", hash = "sha256:2a047b2a98223bb550b00e7776ca469cc902437ea3e265ade8c11135752988c1"},
+    {file = "svgelements-1.6.10.tar.gz", hash = "sha256:80ca705b26103a46256bdbc80ce75e4aa174d94fa7f57a5c9b9253208cd3b6f3"},
 ]
 svgwrite = [
     {file = "svgwrite-1.4.1-py3-none-any.whl", hash = "sha256:4b21652a1d9c543a6bf4f9f2a54146b214519b7540ca60cb99968ad09ef631d0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ pnoise = "^0.1.0"
 Shapely = {extras = ["vectorized"], version = "1.8.0"}  # 1.8.1 breaks win installer
 scipy = "^1.6"
 setuptools = "^51.0.0"
-svgelements = "1.6.9"
+svgelements = "1.6.10"
 svgwrite = "~1.4"
 tomli = "^2.0.0"
 asteval = "^0.9.26"
@@ -81,7 +81,7 @@ docs = ["Sphinx", "sphinx-click", "sphinx-autodoc-typehints", "sphinx-rtd-theme"
 all = ["matplotlib", "glcontext", "moderngl", "Pillow", "PySide2"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.8"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
#### Description

Pinned poetry-core to 1.0.8 to enable editable install

+ updated deps

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
