### PR TITLE
Update codebase to modern typing syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Release date: UNRELEASED
 ### Other changes
 
 * Added support for Python 3.10 and dropped support for Python 3.7 (#417)
+* Updated code base with modern typing syntax (thanks to [pyupgrade](https://github.com/asottile/pyupgrade)) (#427)
 
 
 ## 1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Release date: UNRELEASED
 ### Other changes
 
 * Added support for Python 3.10 and dropped support for Python 3.7 (#417)
-* Updated code base with modern typing syntax (thanks to [pyupgrade](https://github.com/asottile/pyupgrade)) (#427)
+* Updated code base with modern typing syntax (using [pyupgrade](https://github.com/asottile/pyupgrade)) (#427)
 
 
 ## 1.9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import contextlib
 import difflib
 import hashlib
 import os
 import pathlib
 import sys
-from typing import Callable, List
+from typing import Callable
 from xml.dom import minidom
 from xml.etree import ElementTree
 
@@ -132,7 +134,7 @@ def assert_image_similarity(request) -> Callable:
     return _assert_image_similarity
 
 
-def _read_SVG_lines(path: pathlib.Path) -> List[str]:
+def _read_SVG_lines(path: pathlib.Path) -> list[str]:
     tree = ElementTree.parse(path)
     xml_str = ElementTree.tostring(tree.getroot())
     # ET.canonicalize doesn't exist on Python 3.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def assert_image_similarity(request) -> Callable:
     return _assert_image_similarity
 
 
-def _read_SVG_lines(path: pathlib.Path) -> list[str]:
+def _read_svg_lines(path: pathlib.Path) -> list[str]:
     tree = ElementTree.parse(path)
     xml_str = ElementTree.tostring(tree.getroot())
     # ET.canonicalize doesn't exist on Python 3.7
@@ -176,8 +176,8 @@ def reference_svg(request, tmp_path) -> Callable:
             if not ref_path.exists():  # pragma: no cover
                 pytest.fail(f"reference SVG does not exist")
 
-            temp_lines = _read_SVG_lines(temp_file)
-            ref_lines = _read_SVG_lines(ref_path)
+            temp_lines = _read_svg_lines(temp_file)
+            ref_lines = _read_svg_lines(ref_path)
 
             if len(temp_lines) != len(ref_lines) or not all(
                 a == b for a, b in zip(temp_lines, ref_lines)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import vpype as vp

--- a/tests/test_command_files.py
+++ b/tests/test_command_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 
 import pytest

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from dataclasses import dataclass
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def test_config_is_empty(config_manager):
     assert config_manager.config == {}
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,9 +1,10 @@
 """Run a bunch of tests on the svg collection."""
+from __future__ import annotations
+
 import difflib
 import io
 import os
 import re
-from typing import Set
 
 import click
 import numpy as np
@@ -374,7 +375,7 @@ layer 3 property vp_name: (str) my layer 3
 
 
 def test_read_by_attribute():
-    def _prop_set(document: vp.Document, prop: str) -> Set:
+    def _prop_set(document: vp.Document, prop: str) -> set:
         return {layer.property(prop) for layer in document.layers.values()}
 
     file = TEST_FILE_DIRECTORY / "misc" / "multilayer_by_attributes.svg"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/test_hpgl.py
+++ b/tests/test_hpgl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import math
 import random

--- a/tests/test_line_index.py
+++ b/tests/test_line_index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import svgelements
 
 import vpype as vp

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,6 @@
-from typing import Iterable, Sequence, Set, Tuple
+from __future__ import annotations
+
+from typing import Iterable, Sequence
 
 import numpy as np
 import pytest
@@ -31,7 +33,7 @@ EMPTY_LINE_COLLECTION = [
 ]
 
 
-def _line_set(lc: Iterable[Sequence[complex]]) -> Set[Tuple[complex, ...]]:
+def _line_set(lc: Iterable[Sequence[complex]]) -> set[tuple[complex, ...]]:
     return {tuple(line if abs(line[0]) > abs(line[-1]) else reversed(line)) for line in lc}
 
 

--- a/tests/test_reference_output.py
+++ b/tests/test_reference_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import vpype_cli

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import matplotlib.pyplot as plt

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 import pytest
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import vpype as vp

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/tests/test_vpype_primitives.py
+++ b/tests/test_vpype_primitives.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from typing import Sequence
 

--- a/vpype/_deprecated.py
+++ b/vpype/_deprecated.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from .config import config_manager

--- a/vpype/filters.py
+++ b/vpype/filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 
 import numpy as np

--- a/vpype/geometry.py
+++ b/vpype/geometry.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import math
-from typing import List, Optional
 
 import numpy as np
 
@@ -61,7 +62,7 @@ def _interpolate_crop(start: complex, stop: complex, loc: float, axis: int) -> c
 
 def crop_half_plane(
     line: np.ndarray, loc: float, axis: int, keep_smaller: bool
-) -> List[np.ndarray]:
+) -> list[np.ndarray]:
     """Crop a path at a axis-aligned location.
 
     The path is cut at location x=loc for axis=0, and y=loc for axis=1. The argument
@@ -142,14 +143,14 @@ def crop_half_plane(
     return line_arr
 
 
-def _crop_half_plane_mult(lines: List[np.ndarray], loc: float, axis: int, keep_smaller: bool):
+def _crop_half_plane_mult(lines: list[np.ndarray], loc: float, axis: int, keep_smaller: bool):
     new_lines = []
     for line in lines:
         new_lines.extend(crop_half_plane(line, loc=loc, axis=axis, keep_smaller=keep_smaller))
     return new_lines
 
 
-def crop(line: np.ndarray, x1: float, y1: float, x2: float, y2: float) -> List[np.ndarray]:
+def crop(line: np.ndarray, x1: float, y1: float, x2: float, y2: float) -> list[np.ndarray]:
     """Crop a polyline to a rectangular area.
 
     Args:
@@ -168,7 +169,7 @@ def crop(line: np.ndarray, x1: float, y1: float, x2: float, y2: float) -> List[n
     return _crop_half_plane_mult(line_list, y2, axis=1, keep_smaller=True)
 
 
-def reloop(line: np.ndarray, loc: Optional[int] = None) -> np.ndarray:
+def reloop(line: np.ndarray, loc: int | None = None) -> np.ndarray:
     """Change the seam of a closed path. Closed-ness is not checked. Beginning and end points
     are averaged to compute a new point. A new seam location can be provided or will be chosen
     randomly.

--- a/vpype/line_index.py
+++ b/vpype/line_index.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Iterable, Optional, Tuple
+from typing import Iterable
 
 import numpy as np
 from scipy.spatial import cKDTree as KDTree
@@ -55,13 +57,13 @@ class LineIndex:
         self.available[idx] = False
         return self.lines[idx]
 
-    def pop(self, idx: int) -> Optional[np.ndarray]:
+    def pop(self, idx: int) -> np.ndarray | None:
         if not self.available[idx]:
             return None
         self.available[idx] = False
         return self.lines[idx]
 
-    def find_nearest_within(self, p: complex, max_dist: float) -> Tuple[Optional[int], bool]:
+    def find_nearest_within(self, p: complex, max_dist: float) -> tuple[int | None, bool]:
         """Find the closest line, assuming a maximum admissible distance.
         Returns a tuple of (idx, reverse), where `idx` may be None if nothing is found.
         `reverse` indicates whether or not a line ending has been matched instead of a start.
@@ -69,7 +71,7 @@ class LineIndex:
         """
 
         ridx = None
-        rdist: Optional[float] = 0.0
+        rdist: float | None = 0.0
 
         while True:
             reindex, idx, dist = self._find_nearest_within_in_index(p, max_dist, self.index)
@@ -102,7 +104,7 @@ class LineIndex:
 
     def _find_nearest_within_in_index(
         self, p: complex, max_dist: float, index: KDTree
-    ) -> Tuple[bool, Optional[int], Optional[float]]:
+    ) -> tuple[bool, int | None, float | None]:
         """Find nearest in specific index. Return (reindex, idx, dist) tuple, where
         reindex indicates if a reindex is needed.
         """
@@ -127,7 +129,7 @@ class LineIndex:
             return False, None, 0
 
     # noinspection PyUnboundLocalVariable
-    def find_nearest(self, p: complex) -> Tuple[int, bool]:
+    def find_nearest(self, p: complex) -> tuple[int, bool]:
         while True:
             idx, dist = self._find_nearest_in_index(p, self.index)
             if self.reverse:
@@ -147,7 +149,7 @@ class LineIndex:
         else:
             return idx, False
 
-    def _find_nearest_in_index(self, p: complex, index: KDTree) -> Tuple[Optional[int], float]:
+    def _find_nearest_in_index(self, p: complex, index: KDTree) -> tuple[int | None, float]:
         """Check the N nearest lines, hopefully find one that is active."""
 
         dists, idxs = index.query((p.real, p.imag), k=100)

--- a/vpype/metadata.py
+++ b/vpype/metadata.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import dataclasses
 import pathlib
-from typing import Optional, Tuple, Union
 
 import svgelements
 
@@ -33,10 +34,10 @@ class Color:
 
     def __init__(
         self,
-        red: Optional[Union[int, str, "Color", svgelements.Color]] = None,
-        green: Optional[int] = None,
-        blue: Optional[int] = None,
-        alpha: Optional[int] = None,
+        red: int | str | Color | svgelements.Color | None = None,
+        green: int | None = None,
+        blue: int | None = None,
+        alpha: int | None = None,
     ):
         svgc = None
         if isinstance(red, (svgelements.Color, Color)):
@@ -51,7 +52,7 @@ class Color:
         object.__setattr__(self, "blue", int(blue or 0))
         object.__setattr__(self, "alpha", int(alpha or 255))
 
-    def as_floats(self) -> Tuple[float, float, float, float]:
+    def as_floats(self) -> tuple[float, float, float, float]:
         """Returns a float representation of the instance."""
         return self.red / 255, self.green / 255, self.blue / 255, self.alpha / 255
 

--- a/vpype/primitives.py
+++ b/vpype/primitives.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import numpy as np

--- a/vpype/text.py
+++ b/vpype/text.py
@@ -20,12 +20,13 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import annotations
 
 import itertools
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable
 
 from .model import LineCollection
 
@@ -60,14 +61,14 @@ class _Font:
     The glyph data is converted to LineCollection.
     """
 
-    _FONTS: Dict[str, "_Font"] = {}
+    _FONTS: dict[str, _Font] = {}
 
     def __init__(self, name: str):
         with open(_FONT_DIR / (name + ".pickle"), "rb") as fp:
             font_data = pickle.load(fp)
 
         # convert all glyphs to LineCollections
-        self.glyphs: List[_Glyph] = [
+        self.glyphs: list[_Glyph] = [
             _Glyph(
                 lt, rt, LineCollection([[complex(i, j) for i, j in line] for line in lines])
             )
@@ -81,7 +82,7 @@ class _Font:
         self.max_height = all_glyphs.height()
 
     @classmethod
-    def get(cls, font_name: str) -> "_Font":
+    def get(cls, font_name: str) -> _Font:
         """Get _Font instance for provided name, using caching."""
         try:
             if font_name not in cls._FONTS:

--- a/vpype/utils.py
+++ b/vpype/utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import math
 import re
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable
 
 import numpy as np
 
@@ -16,7 +18,7 @@ __all__ = [
 ]
 
 
-def _mm_to_px(x: float, y: float) -> Tuple[float, float]:
+def _mm_to_px(x: float, y: float) -> tuple[float, float]:
     return x * 96.0 / 25.4, y * 96.0 / 25.4
 
 
@@ -53,7 +55,7 @@ PAGE_SIZES = {
 }
 
 
-def _convert_unit(value: Union[str, float], units: Dict[str, float]) -> float:
+def _convert_unit(value: str | float, units: dict[str, float]) -> float:
     """Converts a string with unit to a value"""
     if isinstance(value, str):
         value = value.strip().lower()
@@ -65,7 +67,7 @@ def _convert_unit(value: Union[str, float], units: Dict[str, float]) -> float:
     return float(value)
 
 
-def convert_length(value: Union[str, float]) -> float:
+def convert_length(value: str | float) -> float:
     """Convert a length optionally expressed as a string with unit to px value.
 
     Args:
@@ -80,7 +82,7 @@ def convert_length(value: Union[str, float]) -> float:
     return _convert_unit(value, UNITS)
 
 
-def convert_angle(value: Union[str, float]) -> float:
+def convert_angle(value: str | float) -> float:
     """Convert an angle optionally expressed as a string with unit to degrees.
 
     Args:
@@ -95,7 +97,7 @@ def convert_angle(value: Union[str, float]) -> float:
     return _convert_unit(value, ANGLE_UNITS)
 
 
-def convert_page_size(value: str) -> Tuple[float, float]:
+def convert_page_size(value: str) -> tuple[float, float]:
     """Converts a string with page size to dimension in pixels.
 
     The input can be either a known page size (see ``vpype write --help`` for a list) or
@@ -145,7 +147,7 @@ def convert_page_size(value: str) -> Tuple[float, float]:
     return float(x) * convert_length(x_unit), float(y) * convert_length(y_unit)
 
 
-def union(line: np.ndarray, keys: List[Callable[[np.ndarray], bool]]) -> bool:
+def union(line: np.ndarray, keys: list[Callable[[np.ndarray], bool]]) -> bool:
     """Returns True if every callables in ``keys`` return True (similar to ``all()``. This
     function is typically used with :meth:`LineCollection.filter`.
 

--- a/vpype_cli/blocks.py
+++ b/vpype_cli/blocks.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import glob
 import os
 import pathlib
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Iterable
 
 import click
 
@@ -30,8 +32,8 @@ __all__ = ("grid", "repeat", "forfile", "forlayer")
 def grid(
     state: State,
     processors: Iterable[ProcessorType],
-    number: Tuple[int, int],
-    offset: Tuple[float, float],
+    number: tuple[int, int],
+    offset: tuple[float, float],
 ) -> None:
     """Creates a NX by NY grid of geometry
 
@@ -144,7 +146,7 @@ def forfile(state: State, processors: Iterable[ProcessorType], files: str) -> No
         Process all SVGs in the current directory:
 
     \b
-            $ vpype begin forfile \*.svg read %_path% linemerge linesort \\
+            $ vpype begin forfile \\*.svg read %_path% linemerge linesort \\
                 write "optimized/%basename(_path)%" end
     """
 
@@ -167,7 +169,7 @@ def forfile(state: State, processors: Iterable[ProcessorType], files: str) -> No
 
 
 class _MetadataProxy:
-    def __init__(self, metadata: Dict[str, Any]):
+    def __init__(self, metadata: dict[str, Any]):
         self._metadata = metadata
 
     def __getattr__(self, name):

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 import os
 import random
 import shlex
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, TextIO, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, TextIO, Union, cast
 
 import click
 import numpy as np
@@ -34,7 +36,7 @@ class GroupedGroup(click.Group):
     def command(self, *args, **kwargs):
         """Gather the command help groups"""
         help_group = kwargs.pop("group", None)
-        decorator = super(GroupedGroup, self).command(*args, **kwargs)
+        decorator = super().command(*args, **kwargs)
 
         def wrapper(f):
             cmd = decorator(f)
@@ -100,7 +102,7 @@ class _BrokenCommand(click.Command):  # pragma: no cover
             "\nWarning: entry point could not be loaded. Contact "
             "its author for help.\n\n\b\n" + traceback.format_exc()
         )
-        self.short_help = "\u2020 Warning: could not load plugin. See `%s %s --help`." % (
+        self.short_help = "\u2020 Warning: could not load plugin. See `{} {} --help`.".format(
             util_name,
             self.name,
         )
@@ -235,8 +237,8 @@ def execute_processors(processors: Iterable[ProcessorType], state: State) -> Non
         generated geometries
     """
 
-    outer_processors: List[Any] = []  # gather commands outside of top-level blocks
-    top_level_processors: List[Any] = []  # gather commands inside of top-level blocks
+    outer_processors: list[Any] = []  # gather commands outside of top-level blocks
+    top_level_processors: list[Any] = []  # gather commands inside of top-level blocks
     block = None  # save the current top-level block's block layer_processor
     nested_count = 0  # block depth counter
     expect_block = False  # set to True by `begin` command
@@ -332,7 +334,7 @@ def end():
     return EndBlock()
 
 
-def extract_arguments(f: TextIO) -> List[str]:
+def extract_arguments(f: TextIO) -> list[str]:
     """Read the content of a file-like object and extract the corresponding argument list.
 
     Everything following a '#' is ignored until end of line. Any whitespace is considered
@@ -351,7 +353,7 @@ def extract_arguments(f: TextIO) -> List[str]:
     return args
 
 
-def preprocess_argument_list(args: List[str], cwd: Union[str, None] = None) -> List[str]:
+def preprocess_argument_list(args: list[str], cwd: str | None = None) -> list[str]:
     """Preprocess an argument list, replacing 'include' options by the corresponding file's
     content.
 
@@ -386,7 +388,7 @@ def preprocess_argument_list(args: List[str], cwd: Union[str, None] = None) -> L
                     file_path = os.path.join(cwd, file_path)
                 dir_path = os.path.dirname(file_path)
 
-                with open(file_path, "r") as f:
+                with open(file_path) as f:
                     result.extend(preprocess_argument_list(extract_arguments(f), dir_path))
         else:
             result.append(arg)
@@ -395,7 +397,7 @@ def preprocess_argument_list(args: List[str], cwd: Union[str, None] = None) -> L
 
 
 def execute(
-    pipeline: str, document: Optional[vp.Document] = None, global_opt: str = ""
+    pipeline: str, document: vp.Document | None = None, global_opt: str = ""
 ) -> vp.Document:
     """Execute a vpype pipeline.
 

--- a/vpype_cli/debug.py
+++ b/vpype_cli/debug.py
@@ -1,8 +1,10 @@
 """
 Hidden debug commands to help testing.
 """
+from __future__ import annotations
+
 import json
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Iterable, Sequence
 
 import numpy as np
 
@@ -11,7 +13,7 @@ import vpype as vp
 from .cli import cli
 from .decorators import global_processor
 
-debug_data: List[Dict[str, Any]] = []
+debug_data: list[dict[str, Any]] = []
 
 __all__ = ("dbsample", "dbdump", "stat", "DebugData")
 
@@ -24,7 +26,7 @@ def dbsample(document: vp.Document):
     """
     global debug_data
 
-    data: Dict[str, Any] = {}
+    data: dict[str, Any] = {}
     if document.is_empty():
         data["count"] = 0
     else:
@@ -65,7 +67,7 @@ class DebugData:
         """
         return [DebugData(data) for data in json.loads(debug_output)]
 
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: dict[str, Any]):
         self.count = data["count"]
         self.length = data.get("length", 0)
         self.pen_up_length = data.get("pen_up_length", 0)

--- a/vpype_cli/decorators.py
+++ b/vpype_cli/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 import math
@@ -239,7 +241,7 @@ def block_processor(f):
 
     def new_func(*args, **kwargs):
         # noinspection PyShadowingNames
-        def block_processor(state: State, processors: Iterable["ProcessorType"]) -> None:
+        def block_processor(state: State, processors: Iterable[ProcessorType]) -> None:
             start = datetime.datetime.now()
             new_args, new_kwargs = state.preprocess_arguments(args, kwargs)
             logging.info(f"executing block processor `{f.__name__}` (kwargs: {new_kwargs})")

--- a/vpype_cli/eval.py
+++ b/vpype_cli/eval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import click

--- a/vpype_cli/filters.py
+++ b/vpype_cli/filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 import vpype as vp

--- a/vpype_cli/frames.py
+++ b/vpype_cli/frames.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 import vpype as vp

--- a/vpype_cli/generators.py
+++ b/vpype_cli/generators.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from __future__ import annotations
 
 import click
 import numpy as np
@@ -25,7 +25,7 @@ __all__ = ("random",)
     help="Dimension of the area in which lines are distributed.",
 )
 @generator
-def random(n: int, area: Tuple[float, float]):
+def random(n: int, area: tuple[float, float]):
     """
     Generate random lines.
 

--- a/vpype_cli/layerops.py
+++ b/vpype_cli/layerops.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import random
-from typing import Optional
 
 import click
 
@@ -23,7 +24,7 @@ __all__ = ("lcopy", "lmove", "ldelete", "lreverse", "lswap")
 )
 @click.option("-m", "--no-prop", is_flag=True, help="Do not copy metadata.")
 @global_processor
-def lcopy(document, sources, dest, prob: Optional[float], no_prop: bool):
+def lcopy(document, sources, dest, prob: float | None, no_prop: bool):
     """Copy the content of one or more layer(s) to another layer.
 
     SOURCES can be a single layer ID, the string 'all' (to copy all non-empty layers,
@@ -93,7 +94,7 @@ content is not duplicated:
 )
 @click.option("-m", "--no-prop", is_flag=True, help="Do not move metadata.")
 @global_processor
-def lmove(document, sources, dest, prob: Optional[float], no_prop: bool):
+def lmove(document, sources, dest, prob: float | None, no_prop: bool):
     """Move the content of one or more layer(s) to another layer.
 
     SOURCES can be a single layer ID, the string 'all' (to copy all non-empty layers,
@@ -169,7 +170,7 @@ def lmove(document, sources, dest, prob: Optional[float], no_prop: bool):
     help="Path deletion probability (default: 1.0).",
 )
 @global_processor
-def ldelete(document: vp.Document, layers, keep: bool, prob: Optional[float]) -> vp.Document:
+def ldelete(document: vp.Document, layers, keep: bool, prob: float | None) -> vp.Document:
     """Delete one or more layers.
 
     LAYERS can be a single layer ID, the string 'all' (to delete all layers), or a
@@ -216,7 +217,7 @@ def ldelete(document: vp.Document, layers, keep: bool, prob: Optional[float]) ->
 @click.option("-m", "--no-prop", is_flag=True, help="Do not move metadata.")
 @global_processor
 def lswap(
-    document: vp.Document, first: int, second: int, prob: Optional[float], no_prop: bool
+    document: vp.Document, first: int, second: int, prob: float | None, no_prop: bool
 ) -> vp.Document:
     """Swap the content between two layers
 

--- a/vpype_cli/metadata.py
+++ b/vpype_cli/metadata.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable
 
 import click
 
@@ -22,7 +24,7 @@ __all__ = (
 )
 
 
-_STR_TO_TYPE: Dict[str, Callable] = {
+_STR_TO_TYPE: dict[str, Callable] = {
     "str": str,
     "int": lambda x: int(vp.convert_length(x)),
     "float": vp.convert_length,
@@ -31,8 +33,8 @@ _STR_TO_TYPE: Dict[str, Callable] = {
 
 
 def _check_scope(
-    global_flag: bool, layer: Optional[Union[int, List[int]]]
-) -> Tuple[bool, Optional[Union[int, List[int]]]]:
+    global_flag: bool, layer: int | list[int] | None
+) -> tuple[bool, int | list[int] | None]:
     if global_flag and layer is not None:
         logging.warning(
             "incompatible `--global` and `--layer` options were provided, assuming `--global`"
@@ -64,7 +66,7 @@ def _check_scope(
 def propset(
     document: vp.Document,
     global_flag: bool,
-    layer: Optional[Union[int, List[int]]],
+    layer: int | list[int] | None,
     prop: str,
     value: str,
     prop_type: str,
@@ -134,7 +136,7 @@ def _value_to_str(value: Any) -> str:
 @click.option("--global", "-g", "global_flag", is_flag=True, help="Global mode.")
 @click.option("-l", "--layer", type=LayerType(accept_multiple=True), help="Target layer(s).")
 @global_processor
-def proplist(document: vp.Document, global_flag: bool, layer: Optional[Union[int, List[int]]]):
+def proplist(document: vp.Document, global_flag: bool, layer: int | list[int] | None):
     """Print a list the existing global or layer properties and their values.
 
     Either the `--global` or `--layer` option must be used to specify whether global or
@@ -169,7 +171,7 @@ def proplist(document: vp.Document, global_flag: bool, layer: Optional[Union[int
 @click.option("-l", "--layer", type=LayerType(accept_multiple=True), help="Target layer(s).")
 @global_processor
 def propget(
-    document: vp.Document, global_flag: bool, layer: Optional[Union[int, List[int]]], prop: str
+    document: vp.Document, global_flag: bool, layer: int | list[int] | None, prop: str
 ):
     """Print the value of a global or layer property.
 
@@ -203,7 +205,7 @@ def propget(
 @click.option("-l", "--layer", type=LayerType(accept_multiple=True), help="Target layer(s).")
 @global_processor
 def propdel(
-    document: vp.Document, global_flag: bool, layer: Optional[Union[int, List[int]]], prop: str
+    document: vp.Document, global_flag: bool, layer: int | list[int] | None, prop: str
 ):
     """Remove a global or layer property.
 
@@ -232,9 +234,7 @@ def propdel(
 @click.option("--global", "-g", "global_flag", is_flag=True, help="Global mode.")
 @click.option("-l", "--layer", type=LayerType(accept_multiple=True), help="Target layer(s).")
 @global_processor
-def propclear(
-    document: vp.Document, global_flag: bool, layer: Optional[Union[int, List[int]]]
-):
+def propclear(document: vp.Document, global_flag: bool, layer: int | list[int] | None):
     """Remove all global or layer properties.
 
     Either the `--global` or `--layer` option must be used to specify whether global or

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import cast
 
 import click
 import numpy as np
@@ -58,7 +60,7 @@ def crop(lines: vp.LineCollection, x: float, y: float, width: float, height: flo
 )
 @global_processor
 def trim(
-    document: vp.Document, margin_x: float, margin_y: float, layer: Union[int, List[int]]
+    document: vp.Document, margin_x: float, margin_y: float, layer: int | list[int]
 ) -> vp.Document:
     """Trim the geometries by some margin.
 
@@ -423,8 +425,8 @@ def splitall(lines: vp.LineCollection) -> vp.LineCollection:
 @layer_processor
 def filter_command(
     lines: vp.LineCollection,
-    min_length: Optional[float],
-    max_length: Optional[float],
+    min_length: float | None,
+    max_length: float | None,
     closed: bool,
     not_closed: bool,
     tolerance: float,
@@ -456,8 +458,8 @@ def filter_command(
 
 
 def _normalize_page_size(
-    page_size: Tuple[float, float], landscape: bool
-) -> Tuple[float, float]:
+    page_size: tuple[float, float], landscape: bool
+) -> tuple[float, float]:
     """Normalize page size to respect the orientation."""
     if (landscape and page_size[0] < page_size[1]) or (
         not landscape and page_size[0] > page_size[1]
@@ -564,9 +566,9 @@ Examples:
 @global_processor
 def layout(
     document: vp.Document,
-    size: Tuple[float, float],
+    size: tuple[float, float],
     landscape: bool,
-    margin: Optional[float],
+    margin: float | None,
     align: str,
     valign: str,
 ) -> vp.Document:

--- a/vpype_cli/primitives.py
+++ b/vpype_cli/primitives.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from __future__ import annotations
 
 import click
 
@@ -51,7 +51,7 @@ def rect(
     y: float,
     width: float,
     height: float,
-    radii: Tuple[float, float, float, float],
+    radii: tuple[float, float, float, float],
     quantization: float,
 ) -> vp.LineCollection:
     """Generate a rectangle, with optional rounded angles.

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 import sys
-from typing import List, Optional, Tuple
 
 import click
 
@@ -81,14 +82,14 @@ def read(
     document: vp.Document,
     file,
     single_layer: bool,
-    layer: Optional[int],
-    attr: List[str],
+    layer: int | None,
+    attr: list[str],
     quantization: float,
     no_fail: bool,
     simplify: bool,
     parallel: bool,
     no_crop: bool,
-    display_size: Tuple[float, float],
+    display_size: tuple[float, float],
     display_landscape: bool,
 ) -> vp.Document:
     """Extract geometries from a SVG file.

--- a/vpype_cli/script.py
+++ b/vpype_cli/script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 
 import click
@@ -37,8 +39,6 @@ def script(file) -> vp.LineCollection:
         return LineCollection(module.generate())  # type: ignore
     except Exception as exc:
         raise click.ClickException(
-            (
-                f"the file path must point to a Python script containing a `generate()`"
-                f"function ({str(exc)})"
-            )
+            f"the file path must point to a Python script containing a `generate()`"
+            f"function ({str(exc)})"
         )

--- a/vpype_cli/show.py
+++ b/vpype_cli/show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import click

--- a/vpype_cli/state.py
+++ b/vpype_cli/state.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, Optional, Tuple, Union
+from typing import Any, Generator
 
 import click
 
@@ -34,7 +36,7 @@ class _DeferredEvaluator(ABC):
         self._param_name = param_name
 
     @abstractmethod
-    def evaluate(self, state: "State") -> Any:
+    def evaluate(self, state: State) -> Any:
         """Sub-class must override this function and return the converted value of
         ``self._text``"""
 
@@ -56,19 +58,19 @@ class State:
         document: if provided, use this document
     """
 
-    _current_state: Union["State", None] = None
+    _current_state: State | None = None
 
-    def __init__(self, document: Optional[vp.Document] = None):
+    def __init__(self, document: vp.Document | None = None):
         #: Content of the current pipeline.
         self.document: vp.Document = document or vp.Document()
 
         #: Default layer ID used by :func:`generator` and :func:`layer_processor` commands
         #: when ``--layer`` is not provided.
-        self.target_layer_id: Optional[int] = 1
+        self.target_layer_id: int | None = 1
 
         #: Layer ID being populated by a :func:`generator` or processed by a
         #: :func:`layer_processor` command.
-        self.current_layer_id: Optional[int] = None
+        self.current_layer_id: int | None = None
 
         self._interpreter = SubstitutionHelper(self)
 
@@ -90,8 +92,8 @@ class State:
             return arg.evaluate(self) if isinstance(arg, _DeferredEvaluator) else arg
 
     def preprocess_arguments(
-        self, args: Tuple[Any, ...], kwargs: Dict[str, Any]
-    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         """Evaluate any instance of :class:`_DeferredEvaluator` and replace them with the
         converted value.
         """
@@ -177,7 +179,7 @@ class State:
         self.document = original_doc
 
     @contextmanager
-    def expression_variables(self, variables: Dict[str, Any]) -> Generator[None, None, None]:
+    def expression_variables(self, variables: dict[str, Any]) -> Generator[None, None, None]:
         """Context manager to temporarily set expression variables.
 
         This context manager is typically used by block processors to temporarily set relevant

--- a/vpype_cli/substitution.py
+++ b/vpype_cli/substitution.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import glob
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import asteval
 
@@ -35,12 +37,12 @@ class _PropertyProxy:
         layer_prop: access current layer properties
     """
 
-    def __init__(self, state: "State", global_prop: bool = True, layer_prop: bool = True):
+    def __init__(self, state: State, global_prop: bool = True, layer_prop: bool = True):
         self._state = state
         self._global_prop = global_prop
         self._layer_prop = layer_prop
 
-    def _get_prop(self, name) -> Optional[Any]:
+    def _get_prop(self, name) -> Any | None:
         if self._state.document is None:
             return None
 
@@ -207,7 +209,7 @@ def _substitute_expressions(
     return "".join(_split_text(text, prop_interpreter, expr_interpreter))
 
 
-def _glob(files: str) -> List[pathlib.Path]:
+def _glob(files: str) -> list[pathlib.Path]:
     return [
         pathlib.Path(file) for file in glob.glob(os.path.expandvars(os.path.expanduser(files)))
     ]
@@ -233,7 +235,7 @@ class SubstitutionHelper:
         state: :class:`State` instance
     """
 
-    def __init__(self, state: "State"):
+    def __init__(self, state: State):
         self._property_proxy = _PropertyProxy(state, True, True)
         symtable = {
             **vp.UNITS,
@@ -255,7 +257,7 @@ class SubstitutionHelper:
         )
 
     @property
-    def symtable(self) -> Dict[str, Any]:
+    def symtable(self) -> dict[str, Any]:
         return self._interpreter.symtable
 
     def substitute(self, text: str) -> str:

--- a/vpype_cli/text.py
+++ b/vpype_cli/text.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from __future__ import annotations
 
 import click
 
@@ -37,9 +37,9 @@ def text(
     string: str,
     font: str,
     size: float,
-    wrap: Optional[float],
+    wrap: float | None,
     justify: float,
-    position: Tuple[float, float],
+    position: tuple[float, float],
     align: str,
 ):
     """Generate text using Hershey fonts.

--- a/vpype_cli/transforms.py
+++ b/vpype_cli/transforms.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import Tuple, cast
 
 import click
 
@@ -15,9 +17,9 @@ __all__ = ("rotate", "scale_relative", "scaleto", "skew", "translate")
 
 def _compute_origin(
     document: vp.Document,
-    layer: Optional[Union[int, List[int]]],
-    origin_coords: Optional[Union[Tuple[()], Tuple[float, float]]],
-) -> Tuple[Tuple[float, float], List[int], Tuple[float, float, float, float]]:
+    layer: int | list[int] | None,
+    origin_coords: tuple[()] | tuple[float, float] | None,
+) -> tuple[tuple[float, float], list[int], tuple[float, float, float, float]]:
     layer_ids = multiple_to_layer_ids(layer, document)
     bounds = document.bounds(layer_ids)
 
@@ -39,7 +41,7 @@ def _compute_origin(
 @cli.command(group="Transforms")
 @click.argument("offset", nargs=2, type=LengthType(), required=True)
 @layer_processor
-def translate(lc: vp.LineCollection, offset: Tuple[float, float]):
+def translate(lc: vp.LineCollection, offset: tuple[float, float]):
     """
     Translate the geometries. X and Y offsets must be provided. These arguments understand
     supported units.
@@ -83,9 +85,9 @@ def translate(lc: vp.LineCollection, offset: Tuple[float, float]):
 @global_processor
 def scale_relative(
     document: vp.Document,
-    scale: Tuple[float, float],
-    layer: Union[int, List[int]],
-    origin_coords: Union[Tuple[()], Tuple[float, float]],
+    scale: tuple[float, float],
+    layer: int | list[int],
+    origin_coords: tuple[()] | tuple[float, float],
 ):
     """Scale the geometries by a factor.
 
@@ -147,10 +149,10 @@ def scale_relative(
 @global_processor
 def scaleto(
     document: vp.Document,
-    dim: Tuple[float, float],
-    layer: Union[int, List[int]],
+    dim: tuple[float, float],
+    layer: int | list[int],
     fit_dimensions: bool,
-    origin_coords: Union[Tuple[()], Tuple[float, float]],
+    origin_coords: tuple[()] | tuple[float, float],
 ):
     """Scale the geometries to given dimensions.
 
@@ -219,8 +221,8 @@ def scaleto(
 def rotate(
     document: vp.Document,
     angle: float,
-    layer: Union[int, List[int]],
-    origin_coords: Union[Tuple[()], Tuple[float, float]],
+    layer: int | list[int],
+    origin_coords: tuple[()] | tuple[float, float],
 ):
     """Rotate the geometries (clockwise positive).
 
@@ -271,9 +273,9 @@ def rotate(
 @global_processor
 def skew(
     document: vp.Document,
-    layer: Union[int, List[int]],
-    angles: Tuple[float, float],
-    origin_coords: Union[Tuple[()], Tuple[float, float]],
+    layer: int | list[int],
+    angles: tuple[float, float],
+    origin_coords: tuple[()] | tuple[float, float],
 ):
     """Skew the geometries.
 

--- a/vpype_cli/types.py
+++ b/vpype_cli/types.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar
 
 import click
 
@@ -46,7 +48,7 @@ class TextType(_DeferredEvaluatorType):
     """
 
     class _TextDeferredEvaluator(_DeferredEvaluator):
-        def evaluate(self, state: "State") -> str:
+        def evaluate(self, state: State) -> str:
             return state.substitute(self._text)
 
     name = "text"
@@ -70,7 +72,7 @@ class IntegerType(_DeferredEvaluatorType):
     """
 
     class _IntegerDeferredEvaluator(_DeferredEvaluator):
-        def evaluate(self, state: "State") -> int:
+        def evaluate(self, state: State) -> int:
             return int(state.substitute(self._text))
 
     name = "number"
@@ -100,7 +102,7 @@ class LengthType(_DeferredEvaluatorType):
     """
 
     class _LengthDeferredEvaluator(_DeferredEvaluator):
-        def evaluate(self, state: "State") -> float:
+        def evaluate(self, state: State) -> float:
             return vp.convert_length(state.substitute(self._text))
 
     name = "length"
@@ -127,7 +129,7 @@ class AngleType(_DeferredEvaluatorType):
     """
 
     class _AngleDeferredEvaluator(_DeferredEvaluator):
-        def evaluate(self, state: "State") -> float:
+        def evaluate(self, state: State) -> float:
             return vp.convert_angle(state.substitute(self._text))
 
     name = "angle"
@@ -149,12 +151,12 @@ class PageSizeType(_DeferredEvaluatorType):
         >>> @vpype_cli.cli.command(group="my commands")
         ... @click.argument("fmt", type=vpype_cli.PageSizeType())
         ... @vpype_cli.generator
-        ... def my_command(fmt: Tuple[float, float]):
+        ... def my_command(fmt: tuple[float, float]):
         ...     pass
     """
 
     class _PageSizeDeferredEvaluator(_DeferredEvaluator):
-        def evaluate(self, state: "State") -> Tuple[float, float]:
+        def evaluate(self, state: State) -> tuple[float, float]:
             return vp.convert_page_size(state.substitute(self._text))
 
     name = "pagesize"
@@ -170,13 +172,13 @@ class _DelegatedDeferredEvaluatorType(click.ParamType):
     """
 
     class _DelegatedDeferredEvaluator(_DeferredEvaluator):
-        def __init__(self, text: str, param_name: str, cls: Type, *args, **kwargs):
+        def __init__(self, text: str, param_name: str, cls: type, *args, **kwargs):
             super().__init__(text, param_name)
             self._cls = cls
             self._args = args
             self._kwargs = kwargs
 
-        def evaluate(self, state: "State") -> Any:
+        def evaluate(self, state: State) -> Any:
             delegated = self._cls(*self._args, **self._kwargs)
             return delegated.convert(state.substitute(self._text), None, None)
 
@@ -213,9 +215,7 @@ class FileType(_DelegatedDeferredEvaluatorType):
     _delegate_class = click.File
 
 
-def multiple_to_layer_ids(
-    layers: Optional[Union[int, List[int]]], document: vp.Document
-) -> List[int]:
+def multiple_to_layer_ids(layers: int | list[int] | None, document: vp.Document) -> list[int]:
     """Convert multiple-layer CLI argument to list of layer IDs.
 
     Args:
@@ -240,7 +240,7 @@ def multiple_to_layer_ids(
 
 
 def single_to_layer_id(
-    layer: Optional[int], document: vp.Document, must_exist: bool = False
+    layer: int | None, document: vp.Document, must_exist: bool = False
 ) -> int:
     """Convert single-layer CLI argument to layer ID, accounting for the existence of a current
     a current target layer and dealing with default behavior.
@@ -292,7 +292,7 @@ class LayerType(_DeferredEvaluatorType):
             self._accept_multiple = accept_multiple
             self._accept_new = accept_new
 
-        def evaluate(self, state: "State") -> Union[int, List[int]]:
+        def evaluate(self, state: State) -> int | list[int]:
             value = state.substitute(self._text)
 
             if value.lower() == "all":

--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import os
-from typing import Optional
 
 import click
 
@@ -194,19 +195,19 @@ Examples:
 def write(
     state: State,
     document: vp.Document,
-    cmd_string: Optional[str],
+    cmd_string: str | None,
     output,
     file_format: str,
     page_size: str,
     landscape: bool,
     center: bool,
-    layer_label: Optional[str],
+    layer_label: str | None,
     restore_attribs: bool,
     pen_up: bool,
     color_mode: str,
-    device: Optional[str],
+    device: str | None,
     absolute: bool,
-    velocity: Optional[int],
+    velocity: int | None,
     quiet: bool,
 ):
     """Write command."""

--- a/vpype_viewer/_scales.py
+++ b/vpype_viewer/_scales.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import enum
 from dataclasses import dataclass
-from typing import Tuple
 
 MM_TO_PIXELS = 96.0 / 25.4
 FT_TO_PIXELS = 12 * 96.0
@@ -18,7 +19,7 @@ class UnitType(enum.Enum):
 @dataclass
 class ScaleSpec:
     scale: int  # in display unit
-    divisions: Tuple[int, int, int]  # total sub-division, mid tick, small tick
+    divisions: tuple[int, int, int]  # total sub-division, mid tick, small tick
     to_px: float  # conversion to px
     unit: str  # unit to display
 

--- a/vpype_viewer/_utils.py
+++ b/vpype_viewer/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import Any, Tuple, cast
+from typing import Any, Dict, Tuple, cast
 
 import cachetools
 import cachetools.keys
@@ -14,7 +14,7 @@ ColorType = Tuple[float, float, float, float]
 
 
 @cachetools.cached(
-    cache=cast(dict[Any, Any], {}),
+    cache=cast(Dict[Any, Any], {}),
     key=lambda name, ctx: cachetools.keys.hashkey((name, id(ctx))),
 )
 def load_program(name: str, ctx: mgl.Context) -> mgl.Program:
@@ -50,7 +50,7 @@ def load_program(name: str, ctx: mgl.Context) -> mgl.Program:
 
 
 @cachetools.cached(
-    cache=cast(dict[Any, Any], {}),
+    cache=cast(Dict[Any, Any], {}),
     key=lambda name, ctx, size, components: cachetools.keys.hashkey(
         (name, id(ctx), size, components)
     ),

--- a/vpype_viewer/_utils.py
+++ b/vpype_viewer/_utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 import pathlib
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Tuple, cast
 
 import cachetools
 import cachetools.keys
@@ -12,7 +14,7 @@ ColorType = Tuple[float, float, float, float]
 
 
 @cachetools.cached(
-    cache=cast(Dict[Any, Any], {}),
+    cache=cast(dict[Any, Any], {}),
     key=lambda name, ctx: cachetools.keys.hashkey((name, id(ctx))),
 )
 def load_program(name: str, ctx: mgl.Context) -> mgl.Program:
@@ -31,11 +33,11 @@ def load_program(name: str, ctx: mgl.Context) -> mgl.Program:
         the loaded program
     """
 
-    def _load_shader(path: str) -> Optional[str]:
+    def _load_shader(path: str) -> str | None:
         try:
             with open(path) as fp:
                 return fp.read()
-        except IOError:
+        except OSError:
             return None
 
     full_path = os.path.dirname(__file__) + os.path.sep + "shaders" + os.path.sep + name
@@ -48,13 +50,13 @@ def load_program(name: str, ctx: mgl.Context) -> mgl.Program:
 
 
 @cachetools.cached(
-    cache=cast(Dict[Any, Any], {}),
+    cache=cast(dict[Any, Any], {}),
     key=lambda name, ctx, size, components: cachetools.keys.hashkey(
         (name, id(ctx), size, components)
     ),
 )
 def load_texture_array(
-    name: str, ctx: mgl.Context, size: Tuple[int, int, int], components: int = 4
+    name: str, ctx: mgl.Context, size: tuple[int, int, int], components: int = 4
 ) -> mgl.TextureArray:
     texture_path = pathlib.Path(__file__).parent / "resources" / name
     img = Image.open(str(texture_path))

--- a/vpype_viewer/engine.py
+++ b/vpype_viewer/engine.py
@@ -1,9 +1,11 @@
 """
 Generic viewer
 """
+from __future__ import annotations
+
 import enum
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable
 
 import moderngl as mgl
 import numpy as np
@@ -77,20 +79,20 @@ class Engine:
 
         # state
         self._pixel_factor = 1.0
-        self._ctx: Optional[mgl.Context] = None
+        self._ctx: mgl.Context | None = None
         self._viewport_width = 100
         self._viewport_height = 100
         self._scale = 1.0  # one pixel of page equal one pixel of view port
         self._origin = (0.0, 0.0)  # top-left of page aligned with top-left of view port
-        self._document: Optional[vp.Document] = None
+        self._document: vp.Document | None = None
         self._rebuild_needed = True
         self._scale_spec = DEFAULT_SCALE_SPEC
 
         # painters
-        self._layer_visibility: Dict[int, bool] = defaultdict(lambda: True)
-        self._layer_painters: Dict[int, List[Painter]] = defaultdict(list)
-        self._paper_bounds_painter: Optional[PaperBoundsPainter] = None
-        self._rulers_painter: Optional[RulersPainter] = None
+        self._layer_visibility: dict[int, bool] = defaultdict(lambda: True)
+        self._layer_painters: dict[int, list[Painter]] = defaultdict(list)
+        self._paper_bounds_painter: PaperBoundsPainter | None = None
+        self._rulers_painter: RulersPainter | None = None
 
         self._fit_to_viewport_flag = True
 
@@ -108,12 +110,12 @@ class Engine:
     # Properties
 
     @property
-    def document(self) -> Optional[vp.Document]:
+    def document(self) -> vp.Document | None:
         """:class:`vpype.Document` being displayed."""
         return self._document
 
     @document.setter
-    def document(self, document: Optional[vp.Document]) -> None:
+    def document(self, document: vp.Document | None) -> None:
         self._document = document
         self._layer_visibility.clear()
         self._update()
@@ -130,13 +132,13 @@ class Engine:
         self._update(False)
 
     @property
-    def origin(self) -> Tuple[float, float]:
+    def origin(self) -> tuple[float, float]:
         """Current origin (document coordinates corresponding to the display window's top-left
         corner."""
         return self._origin
 
     @origin.setter
-    def origin(self, origin: Tuple[float, float]):
+    def origin(self, origin: tuple[float, float]):
         self._origin = origin
         self._fit_to_viewport_flag = False
         self._update(False)
@@ -298,7 +300,7 @@ class Engine:
 
         self._update(False)
 
-    def viewport_to_model(self, x: float, y: float) -> Tuple[float, float]:
+    def viewport_to_model(self, x: float, y: float) -> tuple[float, float]:
         """Converts viewport coordinates to model coordinates in pixels."""
         return x / self._scale + self._origin[0], y / self._scale + self._origin[1]
 

--- a/vpype_viewer/image/__init__.py
+++ b/vpype_viewer/image/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from __future__ import annotations
 
 import moderngl
 from PIL import Image
@@ -22,7 +22,7 @@ class ImageRenderer:
         >>> img = renderer.render()
     """
 
-    def __init__(self, size: Tuple[int, int]):
+    def __init__(self, size: tuple[int, int]):
         """Constructor.
 
         Args:
@@ -46,7 +46,7 @@ class ImageRenderer:
 
 def render_image(
     document: vp.Document,
-    size: Tuple[int, int] = (512, 512),
+    size: tuple[int, int] = (512, 512),
     view_mode: ViewMode = ViewMode.PREVIEW,
     show_pen_up: bool = False,
     show_points: bool = False,
@@ -55,8 +55,8 @@ def render_image(
     show_ruler: bool = False,
     pixel_factor: float = 1.0,
     unit_type: UnitType = UnitType.METRIC,
-    scale: Optional[float] = None,
-    origin: Optional[Tuple[float, float]] = None,
+    scale: float | None = None,
+    origin: tuple[float, float] | None = None,
 ) -> Image:
     """Render a :class:`vpype.Document` instance as a Pillow :class:`PIL.Image.Image`.
 

--- a/vpype_viewer/qtviewer/utils.py
+++ b/vpype_viewer/qtviewer/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import signal
 import socket

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -1,12 +1,13 @@
 """
 Qt Viewer
 """
+from __future__ import annotations
+
 import functools
 import logging
 import math
 import os
 import sys
-from typing import Optional, Union
 
 import moderngl as mgl
 from PySide2.QtCore import QEvent, QSettings, QSize, Qt, Signal
@@ -54,7 +55,7 @@ class QtViewerWidget(QGLWidget):
 
     mouse_coords = Signal(str)
 
-    def __init__(self, document: Optional[vp.Document] = None, parent=None):
+    def __init__(self, document: vp.Document | None = None, parent=None):
         """Constructor.
         Args:
             document: the document to display
@@ -78,7 +79,7 @@ class QtViewerWidget(QGLWidget):
         self._factor = 1.0
 
         # deferred initialization in initializeGL()
-        self._ctx: Optional[mgl.Context] = None
+        self._ctx: mgl.Context | None = None
         self._screen = None
         self.engine = Engine(
             view_mode=ViewMode.OUTLINE, show_pen_up=False, render_cb=self.update
@@ -97,11 +98,11 @@ class QtViewerWidget(QGLWidget):
             f"logicalDotsPerInch={screen.logicalDotsPerInch()}, "
         )
 
-    def document(self) -> Optional[vp.Document]:
+    def document(self) -> vp.Document | None:
         """Return the :class:`vpype.Document` currently assigned to the widget."""
         return self._document
 
-    def set_document(self, document: Optional[vp.Document]) -> None:
+    def set_document(self, document: vp.Document | None) -> None:
         """Assign a new :class:`vpype.Document` to the widget."""
         self._document = document
         self.engine.document = document
@@ -216,7 +217,7 @@ class QtViewer(QWidget):
 
     def __init__(
         self,
-        document: Optional[vp.Document] = None,
+        document: vp.Document | None = None,
         view_mode: ViewMode = ViewMode.PREVIEW,
         show_pen_up: bool = False,
         show_points: bool = False,
@@ -389,7 +390,7 @@ class QtViewer(QWidget):
     def add_side_widget(self, widget: QWidget) -> None:
         self._hlayout.addWidget(widget)
 
-    def set_document(self, document: Optional[vp.Document]) -> None:
+    def set_document(self, document: vp.Document | None) -> None:
         self._viewer_widget.set_document(document)
         self._update_layer_menu()
 
@@ -425,12 +426,12 @@ class QtViewer(QWidget):
     def set_show_points(self, show_points: bool) -> None:
         self._viewer_widget.engine.show_points = show_points
 
-    def set_pen_width_mm(self, value: Union[float, QAction]) -> None:
+    def set_pen_width_mm(self, value: float | QAction) -> None:
         if isinstance(value, QAction):
             value = value.data()
         self._viewer_widget.engine.pen_width = value / 25.4 * 96.0
 
-    def set_pen_opacity(self, value: Union[float, QAction]) -> None:
+    def set_pen_opacity(self, value: float | QAction) -> None:
         if isinstance(value, QAction):
             value = value.data()
         self._viewer_widget.engine.pen_opacity = value


### PR DESCRIPTION
#### Description

By using `from __future__ import annotations`, modern typing syntax may be used in a code base intended to run on older python version. This PR systematically adds this statement and comprehensively updates the typing syntax thanks to `pyupgrade`.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
