### PR TITLE
Fixed `Document.add_to_sources()` to also set `vp_source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release date: UNRELEASED
 ### API changes
 
 * Added `vpype_cli.FloatType()`, `vpype_cli.IntRangeType()`, and `vpype_cli.ChoiceType()` (#430)
+* Changed `vpype.Document.add_to_sources()` to also modify the `vp_source` property (#431)
 
 
 ### Other changes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Iterable, Sequence
 
 import numpy as np
@@ -332,3 +333,23 @@ def test_document_exists_none():
     assert doc.exists(1)
     assert not doc.exists(2)
     assert not doc.exists(None)
+
+
+def test_document_add_to_sources(tmp_path):
+    path = tmp_path / "some_file.txt"
+    path.touch()
+
+    doc = Document()
+    doc.add(LineCollection([[0, 1 + 1j], [2 + 2j, 3 + 3j, 4 + 4j]]), 1)
+
+    doc.add_to_sources(path)
+    assert path in doc.property(vp.METADATA_FIELD_SOURCE_LIST)
+    assert path == doc.property(vp.METADATA_FIELD_SOURCE)
+
+    path2 = tmp_path / "doest_exist.txt"
+    doc.add_to_sources(path2)
+    assert path2 not in doc.property(vp.METADATA_FIELD_SOURCE_LIST)
+    assert path2 != doc.property(vp.METADATA_FIELD_SOURCE)
+
+    with pytest.raises(Exception):
+        doc.add_to_sources(sys.stdin)

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -522,7 +522,6 @@ def read_multilayer_svg(
 
     source = _get_source(file)
     if source:
-        document.set_property(METADATA_FIELD_SOURCE, source)
         document.add_to_sources(source)
 
     return document
@@ -586,7 +585,6 @@ def read_svg_by_attributes(
 
     source = _get_source(file)
     if source:
-        document.set_property(METADATA_FIELD_SOURCE, source)
         document.add_to_sources(source)
 
     return document

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -192,7 +192,8 @@ of appearance.
 
     if file == "-":
         file = sys.stdin
-    elif not pathlib.Path(file).is_file():
+        path: pathlib.Path | None = None
+    elif not (path := pathlib.Path(file)).is_file():
         if no_fail:
             logging.debug("read: file doesn't exist, ignoring due to `--no-fail`")
             return document
@@ -219,7 +220,10 @@ of appearance.
 
         document.add(lc, single_to_layer_id(layer, document), with_metadata=True)
         document.extend_page_size((width, height))
-        document.add_to_sources(file)
+
+        # vp_source is not set here, as it becomes a layer property
+        if path:
+            document.sources |= {path.absolute()}
     else:
         if len(attr) == 0:
             doc = vp.read_multilayer_svg(


### PR DESCRIPTION
#### Description

This makes it a more useful API for plug-ins. Also, `ValueError` is no longer silenced.

Fixes #412

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
