### PR TITLE
Fixed scipy.spatial.KDTree import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release date: UNRELEASED
 ### Other changes
 
 * Added support for Python 3.10 and dropped support for Python 3.7 (#417)
+* Miscellaneous code cleaning and fixes (#440, 906087b)
 * Updated installation instructions to use pipx (#428)
 * Updated documentation template (#428)
 * Updated code base with modern typing syntax (using [pyupgrade](https://github.com/asottile/pyupgrade)) (#427)

--- a/vpype/line_index.py
+++ b/vpype/line_index.py
@@ -4,14 +4,14 @@ import logging
 from typing import Iterable
 
 import numpy as np
-from scipy.spatial import cKDTree as KDTree
+from scipy.spatial import KDTree
 
 # REMINDER: anything added here must be added to docs/api.rst
 __all__ = ["LineIndex"]
 
 
 class LineIndex:
-    """Wrapper to scipy.spatial.cKDTree to facilitate systematic processing of a line
+    """Wrapper to scipy.spatial.KDTree to facilitate systematic processing of a line
     collection.
 
     Implementation note: we use the `available` bool array because deleting stuff from the


### PR DESCRIPTION
#### Description

Importing KDTree is preferred to importing cKDTree

Fixes #437 

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
