### PR TITLE
Added an option to `write` to skip the date metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release date: UNRELEASED
 ### New features and improvements
 
 * Added HPGL configuration for the Calcomp Artisan plotter (thanks to Andee Collard and @ithinkido) (#418)
+* Added the `--dont-set-date` option to the `write` command (#442)
 
 
 ### Bug fixes
@@ -18,6 +19,7 @@ Release date: UNRELEASED
 
 * Added `vpype_cli.FloatType()`, `vpype_cli.IntRangeType()`, and `vpype_cli.ChoiceType()` (#430)
 * Changed `vpype.Document.add_to_sources()` to also modify the `vp_source` property (#431)
+* Added a `set_date:bool = True` argument to `vpype.write_svg()` (#442)
 
 
 ### Other changes

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -494,3 +494,15 @@ def test_read_by_attr_stdin_sets_source_properties(monkeypatch):
     doc = vpype_cli.execute(f"read -a stroke -a fill -")
     assert vp.METADATA_FIELD_SOURCE not in doc.metadata
     assert doc.sources == set()
+
+
+def test_write_set_date(capsys):
+    vpype_cli.execute("line 0 0 10 10 write -f svg -")
+    output = capsys.readouterr().out
+    assert "<dc:date>" in output
+
+
+def test_write_dont_set_date(capsys):
+    vpype_cli.execute("line 0 0 10 10 write -f svg --dont-set-date -")
+    output = capsys.readouterr().out
+    assert "<dc:date>" not in output

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -621,6 +621,7 @@ def write_svg(
     show_pen_up: bool = False,
     color_mode: str = "default",
     use_svg_metadata: bool = False,
+    set_date: bool = True,
 ) -> None:
     """Create a SVG from a :py:class:`Document` instance.
 
@@ -665,6 +666,8 @@ def write_svg(
         color_mode: "default" (system property), "none" (no formatting), "layer" (one color per
             layer), "path" (one color per path)
         use_svg_metadata: apply ``svg_``-prefixed properties as SVG attributes
+        set_date: controls whether the current date and time is set in the SVG's metadata
+            (disabling it is useful for auto-generated SVG under VCS)
     """
 
     # compute bounds
@@ -713,8 +716,9 @@ def write_svg(
     fmt.text = "image/svg+xml"
     source = ElementTree.SubElement(work, "dc:source")
     source.text = source_string
-    date = ElementTree.SubElement(work, "dc:date")
-    date.text = datetime.datetime.now().isoformat()
+    if set_date:
+        date = ElementTree.SubElement(work, "dc:date")
+        date.text = datetime.datetime.now().isoformat()
     dwg.set_metadata(metadata)
 
     color_idx = 0

--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -169,7 +169,12 @@ Examples:
     "--restore-attribs",
     is_flag=True,
     default=False,
-    help="[SVG only] attempt to restore SVG attributes from properties",
+    help="[SVG only] attempt to restore SVG attributes from properties.",
+)
+@click.option(
+    "--dont-set-date",
+    is_flag=True,
+    help="[SVG only] do not add date metadata (useful for auto-generated SVG under VCS).",
 )
 @click.option(
     "-d", "--device", type=TextType(), help="[HPGL only] Type of the plotter device."
@@ -203,6 +208,7 @@ def write(
     center: bool,
     layer_label: str | None,
     restore_attribs: bool,
+    dont_set_date: bool,
     pen_up: bool,
     color_mode: str,
     device: str | None,
@@ -238,6 +244,7 @@ def write(
             show_pen_up=pen_up,
             color_mode=color_mode,
             use_svg_metadata=restore_attribs,
+            set_date=not dont_set_date,
         )
     elif file_format == "hpgl":
         if not page_size:


### PR DESCRIPTION
#### Description

For auto-generated SVG under VCS, the <dc:date> metadata generates spurious diffs which would be best avoided.

* adds a `--dont-set-date` option to the `write` command
* adds a `set_date` parameter (default: `True`) to the `vpype.write_svg()` API

Fixes #438

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
