### PR TITLE
Fixed issue #434 where `forlayer` would set `_n` improperly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
+* Fixed issue with `forlayer` where the `_n` variable was set improperly (#443)
 * Fixed issue with `write` where layer opacity was included in the `stroke` attribute instead of using `stroke-opacity`, which, although compliant, was not compatible with Inkscape (#429)
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -692,6 +692,21 @@ def test_forlayer_command_property_accessor():
         assert doc.layers[i + 1].property("test2") == i
 
 
+def test_forlayer_vars():
+    vpype_cli.execute(
+        """
+        repeat 5
+            random -l new
+        end 
+        eval 'cnt=0'
+        forlayer
+            eval 'assert _lid==cnt+1'
+            eval 'assert _i==cnt;cnt += 1'
+            eval 'assert _n==5'
+        end"""
+    )
+
+
 def test_pagerotate():
     doc = vpype_cli.execute("random pagesize a4 pagerotate")
     assert doc.page_size == pytest.approx((1122.5196850393702, 793.7007874015749))

--- a/vpype_cli/blocks.py
+++ b/vpype_cli/blocks.py
@@ -221,13 +221,14 @@ def forlayer(state: State, processors: Iterable[ProcessorType]) -> None:
     orig_doc = state.document
     new_doc: vp.Document = orig_doc.clone()
 
-    for i, lid in enumerate(list(orig_doc.layers)):
+    lids = list(orig_doc.layers)
+    for i, lid in enumerate(lids):
         with state.temp_document(keep_layer=False) as doc:
             doc.add(orig_doc.pop(lid), lid, with_metadata=True)
             variables = {
                 "_lid": lid,
                 "_i": i,
-                "_n": len(doc.layers),
+                "_n": len(lids),
                 "_name": doc.layers[lid].property(vp.METADATA_FIELD_NAME) or "",
                 "_color": doc.layers[lid].property(vp.METADATA_FIELD_COLOR),
                 "_pen_width": doc.layers[lid].property(vp.METADATA_FIELD_PEN_WIDTH),


### PR DESCRIPTION
#### Description

`forlayer` would set `_n` improperly.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
