### PR TITLE
Fix missing plug-ins from `vpype --help` string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* Fixed issue with `forlayer` where the `_n` variable was set improperly (#443)
-* Fixed issue with `write` where layer opacity was included in the `stroke` attribute instead of using `stroke-opacity`, which, although compliant, was not compatible with Inkscape (#429)
+* Fixed an issue with `forlayer` where the `_n` variable was set improperly (#443)
+* Fixed an issue with `write` where layer opacity was included in the `stroke` attribute instead of using `stroke-opacity`, which, although compliant, was not compatible with Inkscape (#429)
+* Fixed an issue with `vpype --help` where commands from plug-ins would not be listed (#444)
+* Fixed a minor issue where plug-ins would be reloaded each time `vpype_cli.execute()` is called (#444) 
 
 
 ### API changes

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,7 +68,7 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "click"
-version = "8.1.1"
+version = "8.1.2"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
@@ -689,8 +689,8 @@ cachetools = [
     {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 click = [
-    {file = "click-8.1.1-py3-none-any.whl", hash = "sha256:5e0d195c2067da3136efb897449ec1e9e6c98282fbf30d7f9e164af9be901a6b"},
-    {file = "click-8.1.1.tar.gz", hash = "sha256:7ab900e38149c9872376e8f9b5986ddcaf68c0f413cf73678a0bca5547e6f976"},
+    {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
+    {file = "click-8.1.2.tar.gz", hash = "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -719,3 +719,11 @@ def test_pagerotate_error(caplog):
     doc = vpype_cli.execute("random pagerotate")
     assert doc.page_size is None
     assert "page size is not defined, page not rotated" in caplog.text
+
+
+def test_help(runner):
+    res = runner.invoke(cli, "--help")
+
+    assert res.exit_code == 0
+    assert "Execute the sequence of commands passed in argument." in res.stdout
+    assert "multipass" in res.stdout


### PR DESCRIPTION
#### Description

When importing plug-ins in the style of `click-plugin` (command decorator, so plug-ins are loaded during the loading of the top-level command itself), plug-ins may not import from `vpype_cli` (since it isn't fully loaded). To address that, since 1.9, loading plug-ins is deferred to when `cli` is actually executed. As a result, the Click's default behaviour for handling `--help` (i.e. print and exit *before* even executing `cli`) is unable to list the plug-ins. This PR addresses this by manually handling the top-level `--help` parameter (*after* plug-ins are loaded).

Fixes #432

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
