### PR TITLE
Fixed bug where `alpha 0` would set the wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Release date: UNRELEASED
 * Added support for Python 3.10 and dropped support for Python 3.7 (#417)
 * Miscellaneous code cleaning and fixes (#440, 906087b)
 * Updated installation instructions to use pipx (#428)
-* Updated documentation template (#428)
+* Updated the [documentation](https://vpype.readthedocs.io/en/latest/) template (#428)
 * Updated code base with modern typing syntax (using [pyupgrade](https://github.com/asottile/pyupgrade)) (#427)
 
 

--- a/vpype/metadata.py
+++ b/vpype/metadata.py
@@ -50,7 +50,7 @@ class Color:
         object.__setattr__(self, "red", int(red or 0))  # type: ignore
         object.__setattr__(self, "green", int(green or 0))
         object.__setattr__(self, "blue", int(blue or 0))
-        object.__setattr__(self, "alpha", int(alpha or 255))
+        object.__setattr__(self, "alpha", int(alpha if alpha is not None else 255))
 
     def as_floats(self) -> tuple[float, float, float, float]:
         """Returns a float representation of the instance."""


### PR DESCRIPTION
#### Description

Bug introduced in #447 

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
