### PR TITLE
Use importlib instead of pkg_resource to find plug-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Release date: UNRELEASED
 
 ### Other changes
 
-* ...
+* Removed dependence on `setuptools` (#454, #468)
 
 
 ## 1.10

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import os
 import random
@@ -10,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, TextIO, Union, cast
 
 import click
 import numpy as np
-from pkg_resources import iter_entry_points
 
 import vpype as vp
 
@@ -198,7 +198,7 @@ def cli(
     global _PLUGINS_LOADED
     if not _PLUGINS_LOADED:
         _PLUGINS_LOADED = True
-        for entry_point in iter_entry_points("vpype.plugins"):
+        for entry_point in importlib.metadata.entry_points().get("vpype.plugins", []):
             # noinspection PyBroadException
             try:
                 cast(click.Group, ctx.command).add_command(entry_point.load())


### PR DESCRIPTION
#### Description

Using `pkg_resource` could lead to issue if `setuptools` isn't installed (plus, importlib is the preferred way to do it).

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
