### PR TITLE
Feature splitdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Release date: UNRELEASED
 
 ### New features and improvements
 
+* Added the `splitdist` command to split layers by drawing distance (thanks to @LoicGoulefert) (#487)
 * Improved the `linemerge` algorithm by making it less dependent on line order (#496)
 * Added HPGL configurations for the Houston Instrument DMP-161, HP7550, Roland DXY 1xxxseries and sketchmate plotters (thanks to @jimmykl and @ithinkido) (#472, #474)
-* Added the `splitdist` command to split lines by drawing distance (#487)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release date: UNRELEASED
 
 * Improved the `linemerge` algorithm by making it less dependent on line order (#496)
 * Added HPGL configurations for the Houston Instrument DMP-161, HP7550, Roland DXY 1xxxseries and sketchmate plotters (thanks to @jimmykl and @ithinkido) (#472, #474)
+* Added the `splitdist` command to split lines by drawing distance (#487)
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ and much more.
 - **Squiggle** filter for shaky-hand or liquid-like styling ([`squiggles`](https://vpype.readthedocs.io/en/latest/reference.html#squiggles))
 - Support for **splitting** all lines to their constituent segments ([`splitall`](https://vpype.readthedocs.io/en/latest/reference.html#splitall)).
 - Support for **reversing** order of paths within their layers ([`reverse`](https://vpype.readthedocs.io/en/latest/reference.html#reverse)).
+- Support for **splitting** lines by drawing distance ([`splitdist`](https://vpype.readthedocs.io/en/latest/reference.html#splitdist))
 
 #### Generation
  

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ and much more.
 - **Squiggle** filter for shaky-hand or liquid-like styling ([`squiggles`](https://vpype.readthedocs.io/en/latest/reference.html#squiggles))
 - Support for **splitting** all lines to their constituent segments ([`splitall`](https://vpype.readthedocs.io/en/latest/reference.html#splitall)).
 - Support for **reversing** order of paths within their layers ([`reverse`](https://vpype.readthedocs.io/en/latest/reference.html#reverse)).
-- Support for **splitting** lines by drawing distance ([`splitdist`](https://vpype.readthedocs.io/en/latest/reference.html#splitdist))
+- Support for **splitting** layers by drawing distance ([`splitdist`](https://vpype.readthedocs.io/en/latest/reference.html#splitdist))
 
 #### Generation
  
@@ -306,7 +306,6 @@ and much more.
  - [vpype-dxf](https://github.com/tatarize/vpype-dxf/): read dxf files
  - [vpype-embroidery](https://github.com/EmbroidePy/vpype-embroidery): various embroidery-related utilities, including read from/write to most embroidery formats 
  - [vpype-vectrace](https://github.com/tatarize/vpype-vectrace): create outlines from images with vector tracing
- - [deduplicate](https://github.com/LoicGoulefert/deduplicate): remove overlapping lines
  
  
  ## Contributing

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -326,6 +326,20 @@ removed thanks to the :ref:`cmd_filter` command::
   $ vpype read input.svg filter --min-length 0.5mm write output.svg
 
 
+Splitting layers by drawing distance
+------------------------------------
+
+Certain medium such as paintbrush or `Posca <https://www.posca.com>`__ pens require manual intervention after a certain drawing distance.
+One way to achieve this is to ensure that the cumulative distance of the lines within each layer remains below that drawing distance.
+This can be achieved using the :ref:`cmd_splitdist` command::
+
+  $ vpype read input.svg splitdist 50cm write output.svg
+
+A finer-grained approach consists of splitting all lines into their constituent segments using the :ref:`cmd_splitall` command and subsequently using the :ref:`cmd_linemerge` to put everything back together::
+
+  $ vpype read input.svg splitall splitdist 50cm linemerge write output.svg
+
+
 HPGL export recipes
 ===================
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -207,6 +207,10 @@ CLI reference
 .. click:: vpype_cli:splitall
    :prog: splitall
 
+.. _cmd_splitdist:
+.. click:: vpype_cli:splitdist
+   :prog: splitdist
+
 .. _cmd_squiggles:
 .. click:: vpype_cli:squiggles
    :prog: squiggles

--- a/poetry.lock
+++ b/poetry.lock
@@ -545,15 +545,16 @@ numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "setuptools-scm"
-version = "6.4.2"
+version = "7.0.0"
 description = "the blessed package to manage your versions by scm tags"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 packaging = ">=20.0"
 tomli = ">=1.0.0"
+typing-extensions = "*"
 
 [package.extras]
 test = ["pytest (>=6.2)", "virtualenv (>20)"]
@@ -617,7 +618,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "types-cachetools"
-version = "5.0.2"
+version = "5.2.0"
 description = "Typing stubs for cachetools"
 category = "dev"
 optional = false
@@ -643,7 +644,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1231,8 +1232,8 @@ scipy = [
     {file = "scipy-1.8.1.tar.gz", hash = "sha256:9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33"},
 ]
 setuptools-scm = [
-    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
-    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
+    {file = "setuptools_scm-7.0.0-py3-none-any.whl", hash = "sha256:187cd31d78998d8226b68d4066dbfbf9c1fa8b61c10ff65cebe950379d3b9175"},
+    {file = "setuptools_scm-7.0.0.tar.gz", hash = "sha256:136fe07547645fee2dcc7d21b192dad95932e70aa4b603f45b8907ed78f44a11"},
 ]
 shapely = [
     {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c9e3400b716c51ba43eea1678c28272580114e009b6c78cdd00c44df3e325fa"},
@@ -1295,8 +1296,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 types-cachetools = [
-    {file = "types-cachetools-5.0.2.tar.gz", hash = "sha256:bf22b2e9f9243983914f6510e43a1873f012afb8c3fc5e09a59b0ccbe3ab0f35"},
-    {file = "types_cachetools-5.0.2-py3-none-any.whl", hash = "sha256:4291c3b6ae10e7b0d7ae3c4cb7d9daa6b21d4b7deb64d193e44bcec7ca5c4095"},
+    {file = "types-cachetools-5.2.0.tar.gz", hash = "sha256:f8ae68aa6502c5c93bbf6ae51ca60fefa9f6a5896846baf7981067809977a61a"},
+    {file = "types_cachetools-5.2.0-py3-none-any.whl", hash = "sha256:ccbcc5e72084c015e2405cb629d769116f7c10f918e3f02d409a94d0167ffaae"},
 ]
 types-pkg-resources = [
     {file = "types-pkg_resources-0.1.3.tar.gz", hash = "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"},

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -102,6 +102,7 @@ MINIMAL_COMMANDS = [
     Command("eval x=2 eval %y=3 eval z=4% eval %w=5%"),
     Command("forlayer text '%_lid% (%_i%/%_n%): %_name%' end"),
     Command("pagerotate", keeps_page_size=False),
+    Command("splitdist 1cm"),
 ]
 
 # noinspection SpellCheckingInspection
@@ -746,3 +747,19 @@ def test_alpha():
     assert vpype_cli.execute("random color red alpha 0.5").layers[1].property(
         vp.METADATA_FIELD_COLOR
     ) == vp.Color(255, 0, 0, 127)
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected_layer_count"),
+    [
+        ("line 0 0 0 5cm", 1),
+        ("line 0 0 0.5cm 0 line 1cm 1cm 1.5cm 1cm", 1),
+        ("line 0 0 0 2cm line 0 2cm 2cm 2cm", 2),
+        ("line 0 0 0 2cm line -l 2 0 2cm 2cm 2cm", 2),
+        ("line 0 0 0 2cm line -l 2 0 2cm 2cm 2cm line -l 2 0 4cm 2cm 4cm", 3),
+    ],
+)
+def test_splitdist(lines, expected_layer_count):
+    doc = vpype_cli.execute(lines + " splitdist 1cm")
+
+    assert len(doc.layers) == expected_layer_count

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -763,3 +763,9 @@ def test_splitdist(lines, expected_layer_count):
     doc = vpype_cli.execute(lines + " splitdist 1cm")
 
     assert len(doc.layers) == expected_layer_count
+
+
+def test_splitdist_ignore_layer():
+    doc = vpype_cli.execute("line 0 0 0 2cm line -l 2 0 2cm 2cm 2cm splitdist -l 1 1cm")
+
+    assert len(doc.layers) == 2

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -710,7 +710,10 @@ def splitdist(
 ) -> vp.Document:
     """Split lines by drawing distance.
 
-    TODO
+    This command will keep the n first lines whose cumulated length is less than dist.
+    The remaining lines are spread to the next available layers.
+    This command works at the line level; calling `splitall` beforehand is required
+    if one wants to work at segment level.
     """
     new_doc = document.clone(keep_layers=True)
     layer_ids = multiple_to_layer_ids(layer, document)

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -705,9 +705,11 @@ def reverse(line_collection: vp.LineCollection) -> vp.LineCollection:
     help="Target layer(s).",
 )
 @global_processor
-def splitdist(document: vp.Document, dist: float, layer: Optional[Union[int, List[int]]]) -> vp.Document:
+def splitdist(
+    document: vp.Document, dist: float, layer: Optional[Union[int, List[int]]]
+) -> vp.Document:
     """Split lines by drawing distance.
-    
+
     TODO
     """
     new_doc = document.clone(keep_layers=True)
@@ -727,7 +729,7 @@ def splitdist(document: vp.Document, dist: float, layer: Optional[Union[int, Lis
             split_lines.append(line)
             cumulative_length += current_line_length
 
-            if cumulative_length >= dist or i == num_lines-1:
+            if cumulative_length >= dist or i == num_lines - 1:
                 if new_doc.layers[layer_id].is_empty():
                     new_doc.add(split_lines, layer_id)
                 else:

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -706,14 +706,15 @@ def reverse(line_collection: vp.LineCollection) -> vp.LineCollection:
 )
 @global_processor
 def splitdist(
-    document: vp.Document, dist: float, layer: Optional[Union[int, List[int]]]
+    document: vp.Document, dist: float, layer: int | list[int] | None
 ) -> vp.Document:
-    """Split lines by drawing distance.
+    """Split layers by drawing distance.
 
-    This command will keep the n first lines whose cumulated length is less than dist.
+    This command will keep the N first lines whose cumulated length is less than DIST.
     The remaining lines are spread to the next available layers.
-    This command works at the line level; calling `splitall` beforehand is required
-    if one wants to work at segment level.
+
+    This command works at the line level. A finer-grained result can be obtained at the segment
+    level using the `splitall splitdist linemerge` sequence of commands.
     """
     new_doc = document.clone(keep_layers=True)
     layer_ids = multiple_to_layer_ids(layer, document)


### PR DESCRIPTION
#### Description

Add `splitdist` command to vpype_cli.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)

####  Manual testing

<details>
  <summary>Base SVGs</summary>
  
  Single layer base SVG
  ![circle_grid_d1cm](https://user-images.githubusercontent.com/25011152/172403430-c49859e2-3c90-4691-b1be-8b0a4f64faf3.svg)

  Multilayer base SVG
  ![multilayer_circle_grid_d1cm](https://user-images.githubusercontent.com/25011152/172403435-c29c80b4-5b14-4b20-8754-85e2f045d3f8.svg)
</details>

<details>
  <summary>splitdist 2cm on single layer SVG</summary>

  `vpype read circle_grid_d1cm.svg splitdist 2cm show`
  ![splitdist_singlelayer_2cm](https://user-images.githubusercontent.com/25011152/172403448-04ce49a4-defa-4323-9b12-1b490376edeb.svg)
</details>

<details>
  <summary>splitdist 12cm on single layer SVG</summary>

   `vpype read circle_grid_d1cm.svg splitdist 12cm show`
   ![splitdist_singlelayer_12cm](https://user-images.githubusercontent.com/25011152/172403455-91e1bac5-dc37-42e3-9a82-55e447572cf2.svg)
</details>

<details>
  <summary>splitall, splitdist 2cm on single layer SVG</summary>

  `vpype read circle_grid_d1cm.svg splitall splitdist 2cm show`
  ![splitall_splitdist_singlelayer_2cm](https://user-images.githubusercontent.com/25011152/172403439-1ac69f55-5389-43ea-8e64-9a7df1ede52a.svg)
</details>

<details>
  <summary>splitdist 2cm on multilayer SVG, all layers</summary>
  
  vpype read multilayer_circle_grid_d1cm.svg splitdist 2cm show
  ![splitdist_multilayer_all_2cm](https://user-images.githubusercontent.com/25011152/172403441-b6b9f95c-f09c-41df-809a-970f234ec8fb.svg)
</details>

<details>
  <summary>splitdist 2cm on multilayer SVG, only layer 2</summary>

  `vpype read multilayer_circle_grid_d1cm.svg splitdist -l 2 2cm show`
  ![splitdist_multilayer_l2_2cm](https://user-images.githubusercontent.com/25011152/172403443-94d8069b-76a9-4d77-a373-cce1464313c8.svg)
</details>





