### PR TITLE
Added `m` and `ft` units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release date: UNRELEASED
 ### New features and improvements
 
 * Added the `splitdist` command to split layers by drawing distance (thanks to @LoicGoulefert) (#487)
+* Added meters (`m`) and feet (`ft`) to the supported units (#498)
 * Improved the `linemerge` algorithm by making it less dependent on line order (#496)
 * Added HPGL configurations for the Houston Instrument DMP-161, HP7550, Roland DXY 1xxxseries and sketchmate plotters (thanks to @jimmykl and @ithinkido) (#472, #474)
 

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -144,7 +144,7 @@ Like the SVG format, the default unit used by *vpype* is the CSS pixel, which is
 
   $ vpype circle 0 0 96
 
-Because the pixel is not the best unit to use with physical media, most commands understand other CSS units including ``in``, ``cm``, ``mm``, ``pt`` and ``pc``. The 1-inch-radius circle can therefore also be generated like this::
+Because the pixel is not the best unit to use with physical media, most commands understand other CSS units including ``in``, ``ft``, ``mm``, ``cm``, ``m``, ``pt`` and ``pc``. The 1-inch-radius circle can therefore also be generated like this::
 
   $ vpype circle 0 0 1in
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -545,7 +545,7 @@ numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "setuptools-scm"
-version = "7.0.0"
+version = "7.0.1"
 description = "the blessed package to manage your versions by scm tags"
 category = "main"
 optional = false
@@ -625,17 +625,9 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "types-pkg-resources"
-version = "0.1.3"
-description = "Typing stubs for pkg_resources"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-toml"
-version = "0.10.7"
-description = "Typing stubs for toml"
+name = "types-setuptools"
+version = "57.4.17"
+description = "Typing stubs for setuptools"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -654,7 +646,7 @@ all = ["matplotlib", "glcontext", "moderngl", "Pillow", "PySide2"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "a1770c380012a3110d0f25ec991a5175ffb430e54f98f07c77e7ca6dcdd03f57"
+content-hash = "9a6f75ea3522aee69edd23fa8516a24ec2f5008ce0a30be9ddf62384976cf9b8"
 
 [metadata.files]
 altgraph = [
@@ -1232,8 +1224,8 @@ scipy = [
     {file = "scipy-1.8.1.tar.gz", hash = "sha256:9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33"},
 ]
 setuptools-scm = [
-    {file = "setuptools_scm-7.0.0-py3-none-any.whl", hash = "sha256:187cd31d78998d8226b68d4066dbfbf9c1fa8b61c10ff65cebe950379d3b9175"},
-    {file = "setuptools_scm-7.0.0.tar.gz", hash = "sha256:136fe07547645fee2dcc7d21b192dad95932e70aa4b603f45b8907ed78f44a11"},
+    {file = "setuptools_scm-7.0.1-py3-none-any.whl", hash = "sha256:23b2e561fd3db49d168f282384af4730092a8c8c6db6d3451ce93a5813c14509"},
+    {file = "setuptools_scm-7.0.1.tar.gz", hash = "sha256:d1c631fc3a4281754274155ef4a40de24b1d1c718df00ead147b08ab690615b2"},
 ]
 shapely = [
     {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c9e3400b716c51ba43eea1678c28272580114e009b6c78cdd00c44df3e325fa"},
@@ -1299,13 +1291,9 @@ types-cachetools = [
     {file = "types-cachetools-5.2.0.tar.gz", hash = "sha256:f8ae68aa6502c5c93bbf6ae51ca60fefa9f6a5896846baf7981067809977a61a"},
     {file = "types_cachetools-5.2.0-py3-none-any.whl", hash = "sha256:ccbcc5e72084c015e2405cb629d769116f7c10f918e3f02d409a94d0167ffaae"},
 ]
-types-pkg-resources = [
-    {file = "types-pkg_resources-0.1.3.tar.gz", hash = "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"},
-    {file = "types_pkg_resources-0.1.3-py2.py3-none-any.whl", hash = "sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c"},
-]
-types-toml = [
-    {file = "types-toml-0.10.7.tar.gz", hash = "sha256:a567fe2614b177d537ad99a661adc9bfc8c55a46f95e66370a4ed2dd171335f9"},
-    {file = "types_toml-0.10.7-py3-none-any.whl", hash = "sha256:05a8da4bfde2f1ee60e90c7071c063b461f74c63a9c3c1099470c08d6fa58615"},
+types-setuptools = [
+    {file = "types-setuptools-57.4.17.tar.gz", hash = "sha256:9d556fcaf6808a1cead4aaa41e5c07a61f0152a875811e1239738eba4e0b7b16"},
+    {file = "types_setuptools-57.4.17-py3-none-any.whl", hash = "sha256:9c7cdaf0d55113e24ac17103bde2d434472abf1dbf444238e989fe4e798ffa26"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,7 @@ packaging = ">=20.8"
 pytest-mpl = ">=0.12"
 mypy = ">=0.901"
 types-cachetools = ">=4.2.4"
-types-toml = ">=0.1.1"
-types-pkg-resources = ">=0.1.2"
+types-setuptools = ">=57.4.17"
 
 [tool.poetry.extras]
 all = ["matplotlib", "glcontext", "moderngl", "Pillow", "PySide2"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+import vpype as vp
+
+
+@pytest.mark.parametrize(
+    "lf rt".split(),
+    [("10cm", "0.1m"), ("10cm", "100mm"), ("6in", ".5ft")],
+)
+def test_convert_length(lf, rt):
+    assert vp.convert_length(lf) == pytest.approx(vp.convert_length(rt))
+
+
+def test_convert_length_fail():
+    with pytest.raises(ValueError):
+        vp.convert_length("invalid")

--- a/vpype/utils.py
+++ b/vpype/utils.py
@@ -22,18 +22,22 @@ def _mm_to_px(x: float, y: float) -> tuple[float, float]:
     return x * 96.0 / 25.4, y * 96.0 / 25.4
 
 
+# NOTE: order matters due to the implementation of _convert_unit()
+
 UNITS = {
     "px": 1.0,
     "in": 96.0,
+    "ft": 12.0 * 96.0,
     "mm": 96.0 / 25.4,
     "cm": 96.0 / 2.54,
+    "m": 100.0 * 96.0 / 2.54,
     "pc": 16.0,
     "pt": 96.0 / 72.0,
 }
 
 ANGLE_UNITS = {
     "deg": 1.0,
-    "grad": 9.0 / 10.0,  # note: must be before "rad"!
+    "grad": 9.0 / 10.0,
     "rad": 180.0 / math.pi,
     "turn": 360.0,
 }


### PR DESCRIPTION
#### Description

Longer units are useful for the new `splitdist` command (#487).

Also cleaned some dev deps.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
