### PR TITLE
Fixed issue in splitdist were metadata wouldn't be propagated to newly created layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release date: UNRELEASED
 
 ### New features and improvements
 
-* Added the `splitdist` command to split layers by drawing distance (thanks to @LoicGoulefert) (#487)
+* Added the `splitdist` command to split layers by drawing distance (thanks to @LoicGoulefert) (#487, #501)
 * Added meters (`m`) and feet (`ft`) to the supported units (#498)
 * Improved the `linemerge` algorithm by making it less dependent on line order (#496)
 * Added HPGL configurations for the Houston Instrument DMP-161, HP7550, Roland DXY 1xxxseries and sketchmate plotters (thanks to @jimmykl and @ithinkido) (#472, #474)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -769,3 +769,16 @@ def test_splitdist_ignore_layer():
     doc = vpype_cli.execute("line 0 0 0 2cm line -l 2 0 2cm 2cm 2cm splitdist -l 1 1cm")
 
     assert len(doc.layers) == 2
+
+
+def test_splitdist_preserves_metadata():
+    doc = vpype_cli.execute(
+        "random -n 200 -a 10cm 10cm name hello color red penwidth 5mm splitdist 10cm"
+    )
+
+    for layer in doc.layers.values():
+        assert layer.metadata[vp.METADATA_FIELD_NAME] == "hello"
+        assert layer.metadata[vp.METADATA_FIELD_COLOR] == vp.Color("red")
+        assert layer.metadata[vp.METADATA_FIELD_PEN_WIDTH] == pytest.approx(
+            vp.convert_length("5mm")
+        )

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -735,9 +735,9 @@ def splitdist(
 
             if cumulative_length >= dist or i == num_lines - 1:
                 if new_doc.layers[layer_id].is_empty():
-                    new_doc.add(split_lines, layer_id)
+                    new_doc.add(split_lines, layer_id, with_metadata=True)
                 else:
-                    new_doc.add(split_lines, new_doc.free_id())
+                    new_doc.add(split_lines, new_doc.free_id(), with_metadata=True)
                 split_lines = lines.clone()
                 cumulative_length = 0
 


### PR DESCRIPTION
#### Description

Fix issue introduced in #487.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
