### PR TITLE
Doc: added new to expression documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release date: UNRELEASED
 
 * Added the `splitdist` command to split layers by drawing distance (thanks to @LoicGoulefert) (#487, #501)
 * Added `--keep-page-size` option to `grid` command (#506)
-* Added meters (`m`) and feet (`ft`) to the supported units (#498)
+* Added meters (`m`) and feet (`ft`) to the supported units (#498, #508)
 * Improved the `linemerge` algorithm by making it less dependent on line order (#496)
 * Added HPGL configurations for the Houston Instrument DMP-161, HP7550, Roland DXY 1xxxseries and sketchmate plotters (thanks to @jimmykl and @ithinkido) (#472, #474)
 * The `forfile` command now sorts the files by their name before processing them (#506)

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -346,9 +346,9 @@ In addition, the following *vpype*-specific symbols are available:
 
   These special objects provide access to the global or current-layer properties. Properties may be accessed by attribute (e.g. ``%prop.vp_name%``) or indexation (e.g. ``%prop['vp_name']%``). The ``gprop`` object provides access to global properties. The ``lprop`` object provides access to the current layer's properties if available (i.e. within  :ref:`generator <fundamentals_generators>` and :ref:`layer processor <fundamentals_layer_processors>` commands). The ``prop`` object looks first for current-layer properties, if any, and then for global properties.
 
-* Units constants (``px``, ``in``, ``mm``, ``cm``, ``pc``, ``pt``).
+* Units constants (``px``, ``in``, ``ft``, ``mm``, ``cm``, ``m``, ``pc``, ``pt``).
 
-  These constants may be used to convert values to CSS pixels unit, which *vpype* uses internally. For example, the expression ``%(3+4)*cm%`` evaluates to the pixel equivalent of 7 centimeters (e.g. ~264.6 pixels).
+  These variables may be used to convert values to CSS pixels unit, which *vpype* uses internally. For example, the expression ``%(3+4)*cm%`` evaluates to the pixel equivalent of 7 centimeters (e.g. ~264.6 pixels). (Note that expressions may overwrite these variables, e.g. to use the ``m`` variable for another purpose.)
 
 * The ``glob(pattern)`` function.
 


### PR DESCRIPTION
#### Description

This commit documents the changes introduced in #498

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
