### PR TITLE
Migrate to Plausible.io (from Google Analytics) for vpype.readthedocs.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Release date: UNRELEASED
 ### Other changes
 
 * [Poetry](https://python-poetry.org) 1.2 or later is not required (developer only) (#541)
-* A `justfile` is now provided for most common operations (install, build the documentation, etc.) (#541) 
+* A `justfile` is now provided for most common operations (install, build the documentation, etc.) (#541)
+* Migrated to [Plausible.io](https://plausible.io) (from Google Analytics) for [vpype.readthedocs.io](https://vpype.readthedocs.io) (#546)
 
 
 ## 1.11

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,0 +1,7 @@
+{% extends "!base.html" %}
+{% block extrahead %}
+    {% if enable_plausible %}
+        <script defer data-domain="vpype.readthedocs.io" data-api="https://sta.abeyeler.workers.dev/sta/event" src="https://sta.abeyeler.workers.dev/sta/script.js"></script>
+    {% endif %}
+    {{ super() }}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,11 @@ rst_prolog = f"""
 """
 
 
+# -- Plausible support
+ENABLE_PLAUSIBLE = os.environ.get("READTHEDOCS_VERSION_TYPE", "") in ["branch", "tag"]
+html_context = {"enable_plausible": ENABLE_PLAUSIBLE}
+
+
 # noinspection PyUnusedLocal
 def autodoc_skip_member(app, what, name, obj, skip, options):
     # noinspection PyBroadException


### PR DESCRIPTION
#### Description

plausible.io > GA because privacy and GDPR.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
