### PR TITLE
Reverted pin of snok/poetry-install due to the Windows on Python 3.8 …

### DIFF
--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install and configure Poetry
-      uses: snok/install-poetry@v1.3.1  # pinned until snok/install-poetry#94 is resolved
+      uses: snok/install-poetry@v1
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true


### PR DESCRIPTION
#### Description

The bug with Windows / Python 3.8 as been resolved in 1.3.3

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
