### PR TITLE
Fixed bug where display would crash with zero width/height page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* ...
+* Fixed a viewer issue where page width/height of 0 would lead to errors and a blank display (#555)
 
 ### API changes
 

--- a/vpype_viewer/engine.py
+++ b/vpype_viewer/engine.py
@@ -300,7 +300,7 @@ class Engine:
         if self._document is None:
             return
 
-        if self._document.page_size is not None:
+        if self._document.page_size is not None and 0 not in self._document.page_size:
             x1, y1 = 0.0, 0.0
             x2, y2 = self._document.page_size
         else:


### PR DESCRIPTION
#### Description

Related to #201, but only address the crashing part.

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
