### PR TITLE
Add special case handling for `layout tight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: UNRELEASED
 
 ### New features and improvements
 
+* The `layout` command now properly handles the `tight` special case by fitting the page size around the existing geometries, accommodating for a margin if provided (#556)
 * Added new units (`yd`, `mi`, and `km`) (#541)
 * Added `inch` unit as a synonym to `in`, useful for expressions (in which `in` is a reserved keyword) (#541)
 * Migrated to PySide6 (from PySide2), which simplifies installation on Apple silicon Macs (#552)


### PR DESCRIPTION
#### Description

The command `layout tight` now fits the page size around the existing geometries, accommodating for a margin if provided.

With an empty pipeline, `layout tight` has no effect (in contrast to other value of SIZE, where the page size is changed).

Fixes #201

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
