### PR TITLE
CI update and cleanup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,7 @@
 name: Benchmarks
 
+# NOTE: manually disabled on GitHub. Most likely needs work to get running again.
+
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,29 +14,16 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pipx install poetry
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get full python version
-      id: full-python-version
-      run: |
-        echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info[:3]))")
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Set up cache
-      uses: actions/cache@v2
-      id: cached-poetry-dependencies
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-    - name: Install dependencies
+        python-version: '3.10'
+        cache: 'poetry'
+    - name: Install project
       run: poetry install -E all
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
     - name: Pytest (benchmark)
       run: |
         poetry run pytest tests/test_benchmarks.py --benchmark-enable --benchmark-json output.json

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -1,4 +1,4 @@
-name: Lint and Tests
+name: Checks, Tests and Installer
 
 on:
   push:
@@ -11,49 +11,52 @@ on:
       - release/*
 
 jobs:
-  #################
-  # TESTS & LINTS #
-  #################
+
+  # ----------------------------------------
+  code-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+      - name: Install project
+        run: poetry install -E all
+      - name: Lint and static analysis
+        run: |
+          poetry run isort --check --diff vpype vpype_cli vpype_viewer tests
+          poetry run black --check --diff vpype vpype_cli vpype_viewer tests
+          poetry run mypy
+
+
+  # ----------------------------------------
   tests:
+    needs: ['code-checks']
     strategy:
       fail-fast: true
       matrix:
         python-version: [3.8, 3.9, '3.10']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         shell: bash
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Get full python version
-      id: full-python-version
-      run: |
-        echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info[:3]))")
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Set up cache
-      uses: actions/cache@v2
-      id: cached-poetry-dependencies
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-    - name: Install dependencies
+        cache: 'poetry'
+    - name: Install project
       run: poetry install -E all
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-    - name: Lint and static analysis
-      run: |
-        poetry run isort --check --diff vpype vpype_cli vpype_viewer tests
-        poetry run black --check --diff vpype vpype_cli vpype_viewer tests
-        poetry run mypy
     # needed for tests to work on ubuntu (libEGL.so.1)
     - name: Install EGL mesa
       if: matrix.os == 'ubuntu-latest'
@@ -70,70 +73,29 @@ jobs:
     - name: Pytest
       run: |
         poetry run pytest
-      if: matrix.os == 'macos-latest' && matrix.python-version != '3.10'
+      if: (matrix.os == 'macos-latest' && matrix.python-version != '3.10') || (matrix.os == 'ubuntu-latest')  # img similarity work with linux?
     - name: Pytest (no image similarity check)
       run: |
         poetry run pytest --skip-image-similarity
       if: matrix.os != 'macos-latest'
-    - name: Upload image comparison test results
-      if: always()
-      uses: actions/upload-artifact@v2
+    - name: Upload comparison test results
+      if: failure()
+      uses: actions/upload-artifact@v3
       with:
-        name: test_report_img_sim_${{ runner.os }}_${{ matrix.python-version }}
-        path: test_report_img_sim/**/*
-    - name: Upload SVG comparison test results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test_report_reference_svg_${{ runner.os }}_${{ matrix.python-version }}
-        path: test_report_reference_svg/**/*
+        name: test_report_${{ runner.os }}_${{ matrix.python-version }}
+        path:
+          - test_report_img_sim/**/*
+          - test_report_reference_svg/**/*
+        if-no-files-found: ignore
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
       if: matrix.os == 'macos-latest' && matrix.python-version == '3.10'
 
 
-  #################
-  # TESTS WINDOWS #
-  #################
-  tests-windows:
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: [3.8, 3.9, '3.10']
-    defaults:
-      run:
-        shell: bash
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Install dependencies
-      run: poetry install -E all
-    - name: Pytest
-      run: |
-        poetry run pytest --skip-image-similarity
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test_report_img_sim_${{ runner.os }}_${{ matrix.python-version }}
-        path: test_report_img_sim/**/*
-
-  #####################
-  # INSTALLER WINDOWS #
-  #####################
+  # ----------------------------------------
   windows-installer:
     defaults:
       run:
@@ -141,30 +103,27 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pipx install poetry
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Install vpype and run PyInstaller
-      id: vpype
+        cache: 'poetry'
+    - name: Install project
+      run: poetry install -E all
+    - name: Run PyInstaller
       run: | 
-        poetry install -E all
         VERSION="`poetry version --short`-${GITHUB_SHA}"
-        echo ::set-output name=version::${VERSION}
-        source $VENV
-        scripts/build.bat
+        echo "version=${VERSION}" >> $GITHUB_ENV
+        poetry run scripts/build.bat
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
         script-file: scripts\installer_win.nsi
-        arguments: /V4 /DVERSION=${{ steps.vpype.outputs.version }}
-    - uses: actions/upload-artifact@v2
+        arguments: /V4 /DVERSION=${{ env.version }}
+    - uses: actions/upload-artifact@v3
       with:
-        name: vpype-${{ steps.vpype.outputs.version }}-setup.exe
-        path: dist/vpype-${{ steps.vpype.outputs.version }}-setup.exe
+        name: vpype-${{ env.version }}-setup.exe
+        path: dist/vpype-${{ env.version }}-setup.exe

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -117,11 +117,14 @@ jobs:
       run: | 
         VERSION="`poetry version --short`-${GITHUB_SHA}"
         echo "version=${VERSION}" >> $GITHUB_ENV
-        poetry run $GITHUB_WORKSPACE\\vpype\\scripts\\build.bat
+        echo version ${VERSION}
+        echo ${GITHUB_WORKSPACE}
+        ls ${GITHUB_WORKSPACE}
+        poetry run ${GITHUB_WORKSPACE}\\vpype\\scripts\\build.bat
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: $GITHUB_WORKSPACE\\vpype\\scripts\\installer_win.nsi
+        script-file: ${GITHUB_WORKSPACE}\\vpype\\scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -103,7 +103,7 @@ jobs:
         echo "version=${VERSION}" >> $GITHUB_ENV
         poetry run ${GITHUB_WORKSPACE}\\scripts\\build.bat
     - name: Create NSIS installer
-      uses: joncloud/makensis-action@v3
+      uses: joncloud/makensis-action@v3.7
       with:
         script-file: scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -103,7 +103,7 @@ jobs:
         echo "version=${VERSION}" >> $GITHUB_ENV
         poetry run ${GITHUB_WORKSPACE}\\scripts\\build.bat
     - name: Create NSIS installer
-      uses: joncloud/makensis-action@v3.3
+      uses: joncloud/makensis-action@v3
       with:
         script-file: scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.8, 3.9, '3.10']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest] # FIXME:, windows-latest]
     defaults:
       run:
         shell: bash
@@ -117,11 +117,11 @@ jobs:
       run: | 
         VERSION="`poetry version --short`-${GITHUB_SHA}"
         echo "version=${VERSION}" >> $GITHUB_ENV
-        poetry run scripts/build.bat
+        poetry run $GITHUB_WORKSPACE\vpype\scripts\build.bat
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: scripts\installer_win.nsi
+        script-file: $GITHUB_WORKSPACE\vpype\scripts\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Pytest
       run: |
         poetry run pytest
-      if: (matrix.os == 'macos-latest' && matrix.python-version != '3.10') || (matrix.os == 'ubuntu-latest')  # img similarity work with linux?
+      if: matrix.os == 'macos-latest' && matrix.python-version != '3.10'
     - name: Pytest (no image similarity check)
       run: |
         poetry run pytest --skip-image-similarity
@@ -117,11 +117,11 @@ jobs:
       run: | 
         VERSION="`poetry version --short`-${GITHUB_SHA}"
         echo "version=${VERSION}" >> $GITHUB_ENV
-        poetry run $GITHUB_WORKSPACE\vpype\scripts\build.bat
+        poetry run $GITHUB_WORKSPACE\\vpype\\scripts\\build.bat
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: $GITHUB_WORKSPACE\vpype\scripts\installer_win.nsi
+        script-file: $GITHUB_WORKSPACE\\vpype\\scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -1,4 +1,4 @@
-name: Checks, Tests and Installer
+name: CI
 
 on:
   push:
@@ -13,29 +13,7 @@ on:
 jobs:
 
   # ----------------------------------------
-  code-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install poetry
-        run: pipx install poetry
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'poetry'
-      - name: Install project
-        run: poetry install -E all
-      - name: Lint and static analysis
-        run: |
-          poetry run isort --check --diff vpype vpype_cli vpype_viewer tests
-          poetry run black --check --diff vpype vpype_cli vpype_viewer tests
-          poetry run mypy
-
-
-  # ----------------------------------------
-  tests:
-    needs: ['code-checks']
+  lint-tests:
     strategy:
       fail-fast: true
       matrix:
@@ -57,6 +35,12 @@ jobs:
         cache: 'poetry'
     - name: Install project
       run: poetry install -E all
+    - name: Lint and static analysis
+      if:  matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'  # no need to run that 9x
+      run: |
+        poetry run isort --check --diff vpype vpype_cli vpype_viewer tests
+        poetry run black --check --diff vpype vpype_cli vpype_viewer tests
+        poetry run mypy
     # needed for tests to work on ubuntu (libEGL.so.1)
     - name: Install EGL mesa
       if: matrix.os == 'ubuntu-latest'
@@ -121,7 +105,7 @@ jobs:
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: ${GITHUB_WORKSPACE}\\scripts\\installer_win.nsi
+        script-file: scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.8, 3.9, '3.10']
-        os: [ubuntu-latest, macos-latest] # FIXME:, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         shell: bash
@@ -117,14 +117,11 @@ jobs:
       run: | 
         VERSION="`poetry version --short`-${GITHUB_SHA}"
         echo "version=${VERSION}" >> $GITHUB_ENV
-        echo version ${VERSION}
-        echo ${GITHUB_WORKSPACE}
-        ls ${GITHUB_WORKSPACE}
-        poetry run ${GITHUB_WORKSPACE}\\vpype\\scripts\\build.bat
+        poetry run ${GITHUB_WORKSPACE}\\scripts\\build.bat
     - name: Create NSIS installer
       uses: joncloud/makensis-action@v3.3
       with:
-        script-file: ${GITHUB_WORKSPACE}\\vpype\\scripts\\installer_win.nsi
+        script-file: ${GITHUB_WORKSPACE}\\scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -83,9 +83,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test_report_${{ runner.os }}_${{ matrix.python-version }}
-        path:
-          - test_report_img_sim/**/*
-          - test_report_reference_svg/**/*
+        path: |
+          test_report_img_sim/**/*
+          test_report_reference_svg/**/*
         if-no-files-found: ignore
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
-
 name: Release
 
 on:
@@ -7,118 +6,63 @@ on:
       - '*.*.*'
 
 jobs:
-  
-  ########################
-  # RELEASE CREATION JOB #
-  ########################
-  job_release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      tag: ${{ steps.tag.outputs.tag }}
-    steps:
-    - name: Get tag
-      id: tag
-      run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
-    - uses: actions/checkout@v3
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.tag.outputs.tag }}
-        release_name: vpype ${{ steps.tag.outputs.tag }}
-        draft: true
-        prerelease: false
 
-
-  ###########################
-  # BUILD WINDOWS INSTALLER #
-  ###########################
-  job_win_installer:
-    name: Windows Installer
+  # ----------------------------------------
+  gh-release-installer:
     defaults:
       run:
         shell: bash
     runs-on: windows-latest
-    needs: job_release
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - name: Install poetry
+      run: pipx install poetry
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Build and run PyInstaller
-      id: build
-      run: | 
-        poetry install -E all
-        echo ::set-output name=version::`poetry version --short`
-        source $VENV
-        scripts/build.bat
+        # no caching!
+    - name: Install project
+      run: poetry install -E all
+    - name: Run PyInstaller
+      run: |
+        VERSION="`poetry version --short`"
+        echo "version=${VERSION}" >> $GITHUB_ENV
+        poetry run ${GITHUB_WORKSPACE}\\scripts\\build.bat
     - name: Create NSIS installer
-      uses: joncloud/makensis-action@v3.3
+      uses: joncloud/makensis-action@v3
       with:
-        script-file: scripts\installer_win.nsi
-        arguments: /V4 /DVERSION=${{ steps.build.outputs.version }}
-    - name: Upload Windows installer
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        script-file: scripts\\installer_win.nsi
+        arguments: /V4 /DVERSION=${{ env.version }}
+    - name: Make GH Release
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ needs.job_release.outputs.upload_url }}
-        asset_path: dist/vpype-${{ steps.build.outputs.version }}-setup.exe
-        asset_name: vpype-${{ steps.build.outputs.version }}-setup.exe
-        asset_content_type: application/octet-stream
+        draft: true
+        files: dist/vpype-${{ env.version }}-setup.exe
+        fail_on_unmatched_files: true
 
 
-  ##################
-  # UPLOAD TO PYPI #
-  ##################
-  job_pypi:
-    name: Upload to PyPI
+  # ----------------------------------------
+  pypi-upload:
     runs-on: ubuntu-latest
-    # do not run if windows installer failed
-    needs: [job_release, job_win_installer]
+    needs: [windows-installer]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
+      - name: Build artifacts
+        run: poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: Build
-        id: build
-        run: |
-          poetry build
-          source $VENV
-          pip install packaging
-          echo ::set-output name=version::`poetry version -s | python -c "import packaging.version,sys;print(packaging.version.parse(sys.stdin.read()))"`
-      - name: Upload File Assets
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.job_release.outputs.upload_url }}
-          asset_path: dist/vpype-${{ steps.build.outputs.version }}.tar.gz
-          asset_name: vpype-${{ steps.build.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-      - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          # repository_url: https://test.pypi.org/legacy/
-          password: ${{ secrets.PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          # FIXME
+          #password: ${{ secrets.PYPI_TOKEN }}
           # skip_existing: true
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         echo "version=${VERSION}" >> $GITHUB_ENV
         poetry run ${GITHUB_WORKSPACE}\\scripts\\build.bat
     - name: Create NSIS installer
-      uses: joncloud/makensis-action@v3
+      uses: joncloud/makensis-action@v3.7
       with:
         script-file: scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       id: tag
       run: |
         echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -47,7 +47,7 @@ jobs:
     needs: job_release
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
@@ -89,7 +89,7 @@ jobs:
     # do not run if windows installer failed
     needs: [job_release, job_win_installer]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
   # ----------------------------------------
   pypi-upload:
     runs-on: ubuntu-latest
-    needs: [windows-installer]
+    needs: [gh-release-installer]
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
         script-file: scripts\\installer_win.nsi
         arguments: /V4 /DVERSION=${{ env.version }}
     - name: Make GH Release
-      uses: softprops/action-gh-release@v1
+      uses: ncipollo/release-action@v1
       with:
         draft: true
-        files: dist/vpype-${{ env.version }}-setup.exe
+        artifacts: dist/vpype-${{ env.version }}-setup.exe
         fail_on_unmatched_files: true
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       with:
         draft: true
         artifacts: dist/vpype-${{ env.version }}-setup.exe
-        fail_on_unmatched_files: true
 
 
   # ----------------------------------------
@@ -60,9 +59,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          # FIXME
-          #password: ${{ secrets.PYPI_TOKEN }}
-          # skip_existing: true
+          # repository_url: https://test.pypi.org/legacy/
+          # password: ${{ secrets.TEST_PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}
           verbose: true


### PR DESCRIPTION
#### Description

CI currently generate *many* warning. This PR cleans that up.

- Simplified caching by using setup-python's capability
- Code checks (lint, mypy) are now executed only once.
- Release: Now a single job builds the installer and creates the GH release
- Release: the wheel/source is no longer uploaded to the release (GH does that already)
- Many cleanup, updates, and simplifications

#### Checklist

- [x] feature/fix implemented
- [ ] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [ ] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
