### PR TITLE
Fix layer ID determination to use only the first group of contiguous digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* ...
+* Fixed a design issue with the `read` command where disjoints groups of digit in layer names would be used to determine layer IDs. Only the first contiguous group of digit is used, so a layer named "01-layer1" would now have layer ID of 1 instead of 11
 
 ### API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* Fixed a design issue with the `read` command where disjoints groups of digit in layer names would be used to determine layer IDs. Only the first contiguous group of digit is used, so a layer named "01-layer1" would now have layer ID of 1 instead of 11
+* Fixed a design issue with the `read` command where disjoints groups of digit in layer names would be used to determine layer IDs. Only the first contiguous group of digit is used, so a layer named "01-layer1" would now have layer ID of 1 instead of 11 (#606)
 
 ### API changes
 

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -91,9 +91,9 @@ def read(
     display_size: tuple[float, float] | None,
     display_landscape: bool,
 ) -> vp.Document:
-    """Extract geometries from a SVG file.
+    """Extract geometries from an SVG file.
 
-    FILE may be a file path path or a dash (-) to read from the standard input instead.
+    FILE may be a file path or a dash (-) to read from the standard input instead.
 
     By default, the `read` command attempts to preserve the layer structure of the SVG. In this
     context, top-level groups (<g>) are each considered a layer. If any, all non-group,
@@ -102,9 +102,9 @@ def read(
     The following logic is used to determine in which layer each SVG top-level group is
     imported:
 
-        - If a `inkscape:label` attribute is present and contains digit characters, it is \
-stripped of non-digit characters the resulting number is used as target layer. If the \
-resulting number is 0, layer 1 is used instead.
+        - If a `inkscape:label` attribute is present and contains digit characters, the first \
+group of contiguous digits is used as target layer. If the resulting number is 0, layer 1 is \
+used instead.
 
         - If the previous step fails, the same logic is applied to the `id` attribute.
 
@@ -141,7 +141,7 @@ of appearance.
     length attributes. The crop operation can be disabled with the `--no-crop` option.
 
     In general, SVG boundaries are determined by the `width` and `height` of the top-level
-    <svg> tag. However, the some SVG may have their width and/or height specified as percent
+    <svg> tag. However, some SVGs may have their width and/or height specified as percent
     value or even miss them altogether (in which case they are assumed to be set to 100%). In
     these cases, vpype attempts to use the `viewBox` attribute to determine the page size, or
     revert to a 1000x1000px default. The options `--display-size FORMAT` and


### PR DESCRIPTION
#### Description

This address WTF cases like `01-layer1` ending in layer 11, but does *not* address cases like both `green1` and `blue1` ending in layer 1 (#594). This would require use the AxiDraw semantic (layer ID must be the first non-whitespace character), but would break situation like `layer 1` and `layer 3`.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [ ] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [x] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
