### PR TITLE
Fixed Wayland-related crash by setting QT_QPA_PLATFORM to "xcb"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Release date: UNRELEASED
 ### Bug fixes
 
 * Fixed a design issue with the `read` command where disjoints groups of digit in layer names would be used to determine layer IDs. Only the first contiguous group of digit is used, so a layer named "01-layer1" would now have layer ID of 1 instead of 11 (#606)
-* Fixed an issue on Wayland-based Linux distribution where using the viewer (e.g. with the `show` command) would crash
+* Fixed an issue on Wayland-based Linux distribution where using the viewer (e.g. with the `show` command) would crash (#607)
 
 ### API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: UNRELEASED
 ### Bug fixes
 
 * Fixed a design issue with the `read` command where disjoints groups of digit in layer names would be used to determine layer IDs. Only the first contiguous group of digit is used, so a layer named "01-layer1" would now have layer ID of 1 instead of 11 (#606)
+* Fixed an issue on Wayland-based Linux distribution where using the viewer (e.g. with the `show` command) would crash
 
 ### API changes
 

--- a/vpype_viewer/qtviewer/__init__.py
+++ b/vpype_viewer/qtviewer/__init__.py
@@ -1,1 +1,18 @@
+def _check_wayland():
+    """Fix QT env variable on Wayland-based systems.
+
+    See https://github.com/abey79/vpype/issues/596
+    """
+    import os
+    import sys
+
+    if sys.platform.startswith("linux"):
+        if os.environ.get("XDG_SESSION_TYPE", "") == "wayland":
+            if "QT_QPA_PLATFORM" not in os.environ:
+                os.environ["QT_QPA_PLATFORM"] = "xcb"
+
+
+_check_wayland()
+
+
 from .viewer import *


### PR DESCRIPTION
#### Description

Fixes #596

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
