### PR TITLE
Migrate to Ruff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ _to be completed_
 #### Checklist
 
 - [ ] feature/fix implemented
-- [ ] code formatting ok (`black` and `isort`)
+- [ ] code formatting ok (`black` and `ruff check .`)
 - [ ] `mypy` returns no error
 - [ ] tests added/updated and `pytest` succeeds
 - [ ] documentation added/updated

--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Lint and static analysis
       if:  matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'  # no need to run that 9x
       run: |
-        poetry run isort --check --diff vpype vpype_cli vpype_viewer tests
+        poetry run ruff check --show-source vpype vpype_cli vpype_viewer tests
         poetry run black --check --diff vpype vpype_cli vpype_viewer tests
         poetry run mypy
     # needed for tests to work on ubuntu (libEGL.so.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Release date: UNRELEASED
 
 * Fixed issue with ImageRenderer where the GL context wasn't released, ultimately causing a crash when running the test suite (which could involve many hundreds of context creation) (#616)
 
+### Other changes
+
+* The project now uses [Ruff](https://github.com/astral-sh/ruff) for linting (supersedes isort) (#646)
+
 
 ## 1.13
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 
@@ -90,7 +92,7 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
     try:
         if "_deprecated" in str(obj.__module__):
             return True
-    except:
+    except:  # noqa: E722
         pass
 
     if name.startswith("__") and name.endswith("__"):

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,36 +70,33 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "23.3.0"
+version = "23.7.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
-    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
-    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
-    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
-    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
-    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
-    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
-    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
-    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
-    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
-    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
-    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
-    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
-    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be"},
+    {file = "black-23.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc"},
+    {file = "black-23.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a"},
+    {file = "black-23.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926"},
+    {file = "black-23.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6"},
+    {file = "black-23.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a"},
+    {file = "black-23.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087"},
+    {file = "black-23.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91"},
+    {file = "black-23.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491"},
+    {file = "black-23.7.0-py3-none-any.whl", hash = "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96"},
+    {file = "black-23.7.0.tar.gz", hash = "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb"},
 ]
 
 [package.dependencies]
@@ -225,13 +222,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.4"
+version = "8.1.5"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.4-py3-none-any.whl", hash = "sha256:2739815aaa5d2c986a88f1e9230c55e17f0caad3d958a5e13ad0797c166db9e3"},
-    {file = "click-8.1.4.tar.gz", hash = "sha256:b97d0c74955da062a7d4ef92fadb583806a585b2ea81958a81bd72726cbb8e37"},
+    {file = "click-8.1.5-py3-none-any.whl", hash = "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"},
+    {file = "click-8.1.5.tar.gz", hash = "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367"},
 ]
 
 [package.dependencies]
@@ -433,45 +430,45 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fonttools"
-version = "4.40.0"
+version = "4.41.0"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b802dcbf9bcff74672f292b2466f6589ab8736ce4dcf36f48eb994c2847c4b30"},
-    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7f6e3fa3da923063c286320e728ba2270e49c73386e3a711aa680f4b0747d692"},
-    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdf60f8a5c6bcce7d024a33f7e4bc7921f5b74e8ea13bccd204f2c8b86f3470"},
-    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91784e21a1a085fac07c6a407564f4a77feb471b5954c9ee55a4f9165151f6c1"},
-    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:05171f3c546f64d78569f10adc0de72561882352cac39ec7439af12304d8d8c0"},
-    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7449e5e306f3a930a8944c85d0cbc8429cba13503372a1a40f23124d6fb09b58"},
-    {file = "fonttools-4.40.0-cp310-cp310-win32.whl", hash = "sha256:bae8c13abbc2511e9a855d2142c0ab01178dd66b1a665798f357da0d06253e0d"},
-    {file = "fonttools-4.40.0-cp310-cp310-win_amd64.whl", hash = "sha256:425b74a608427499b0e45e433c34ddc350820b6f25b7c8761963a08145157a66"},
-    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:00ab569b2a3e591e00425023ade87e8fef90380c1dde61be7691cb524ca5f743"},
-    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:18ea64ac43e94c9e0c23d7a9475f1026be0e25b10dda8f236fc956188761df97"},
-    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:022c4a16b412293e7f1ce21b8bab7a6f9d12c4ffdf171fdc67122baddb973069"},
-    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530c5d35109f3e0cea2535742d6a3bc99c0786cf0cbd7bb2dc9212387f0d908c"},
-    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5e00334c66f4e83535384cb5339526d01d02d77f142c23b2f97bd6a4f585497a"},
-    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb52c10fda31159c22c7ed85074e05f8b97da8773ea461706c273e31bcbea836"},
-    {file = "fonttools-4.40.0-cp311-cp311-win32.whl", hash = "sha256:6a8d71b9a5c884c72741868e845c0e563c5d83dcaf10bb0ceeec3b4b2eb14c67"},
-    {file = "fonttools-4.40.0-cp311-cp311-win_amd64.whl", hash = "sha256:15abb3d055c1b2dff9ce376b6c3db10777cb74b37b52b78f61657634fd348a0d"},
-    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14037c31138fbd21847ad5e5441dfdde003e0a8f3feb5812a1a21fd1c255ffbd"},
-    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:94c915f6716589f78bc00fbc14c5b8de65cfd11ee335d32504f1ef234524cb24"},
-    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37467cee0f32cada2ec08bc16c9c31f9b53ea54b2f5604bf25a1246b5f50593a"},
-    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d4d85f5374b45b08d2f928517d1e313ea71b4847240398decd0ab3ebbca885"},
-    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8c4305b171b61040b1ee75d18f9baafe58bd3b798d1670078efe2c92436bfb63"},
-    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a954b90d1473c85a22ecf305761d9fd89da93bbd31dae86e7dea436ad2cb5dc9"},
-    {file = "fonttools-4.40.0-cp38-cp38-win32.whl", hash = "sha256:1bc4c5b147be8dbc5df9cc8ac5e93ee914ad030fe2a201cc8f02f499db71011d"},
-    {file = "fonttools-4.40.0-cp38-cp38-win_amd64.whl", hash = "sha256:8a917828dbfdb1cbe50cf40eeae6fbf9c41aef9e535649ed8f4982b2ef65c091"},
-    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:882983279bf39afe4e945109772c2ffad2be2c90983d6559af8b75c19845a80a"},
-    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c55f1b4109dbc3aeb496677b3e636d55ef46dc078c2a5e3f3db4e90f1c6d2907"},
-    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec468c022d09f1817c691cf884feb1030ef6f1e93e3ea6831b0d8144c06480d1"},
-    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d5adf4ba114f028fc3f5317a221fd8b0f4ef7a2e5524a2b1e0fd891b093791a"},
-    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:aa83b3f151bc63970f39b2b42a06097c5a22fd7ed9f7ba008e618de4503d3895"},
-    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:97d95b8301b62bdece1af943b88bcb3680fd385f88346a4a899ee145913b414a"},
-    {file = "fonttools-4.40.0-cp39-cp39-win32.whl", hash = "sha256:1a003608400dd1cca3e089e8c94973c6b51a4fb1ef00ff6d7641617b9242e637"},
-    {file = "fonttools-4.40.0-cp39-cp39-win_amd64.whl", hash = "sha256:7961575221e3da0841c75da53833272c520000d76f7f71274dbf43370f8a1065"},
-    {file = "fonttools-4.40.0-py3-none-any.whl", hash = "sha256:200729d12461e2038700d31f0d49ad5a7b55855dec7525074979a06b46f88505"},
-    {file = "fonttools-4.40.0.tar.gz", hash = "sha256:337b6e83d7ee73c40ea62407f2ce03b07c3459e213b6f332b94a69923b9e1cb9"},
+    {file = "fonttools-4.41.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ba2a367ff478cd108d5319c0dc4fd4eb4ea3476dbfc45b00c45718e889cd9463"},
+    {file = "fonttools-4.41.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:69178674505ec81adf4af2a3bbacd0cb9a37ba7831bc3fca307f80e48ab2767b"},
+    {file = "fonttools-4.41.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86edb95c4d1fe4fae2111d7e0c10c6e42b7790b377bcf1952303469eee5b52bb"},
+    {file = "fonttools-4.41.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50f8bdb421270f71b54695c62785e300fab4bb6127be40bf9f3084962a0c3adb"},
+    {file = "fonttools-4.41.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c890061915e95b619c1d3cc3c107c6fb021406b701c0c24b03e74830d522f210"},
+    {file = "fonttools-4.41.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b329ae7ce971b5c4148d6cdb8119c0ce4587265b2330d4f2f3776ef851bee020"},
+    {file = "fonttools-4.41.0-cp310-cp310-win32.whl", hash = "sha256:bc9e7b1e268be7a23fc66471b615c324e99c5db39ce8c49dd6dd8e962c7bc1b8"},
+    {file = "fonttools-4.41.0-cp310-cp310-win_amd64.whl", hash = "sha256:f3fe90dfb297bd8265238c06787911cd81c2cb89ac5b13e1c911928bdabfce0f"},
+    {file = "fonttools-4.41.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e38bd91eae257f36c2b7245c0278e9cd9d754f3a66b8d2b548c623ba66e387b6"},
+    {file = "fonttools-4.41.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:415cf7c806a3f56fb280dadcf3c92c85c0415e75665ca957b4a2a2e39c17a5c9"},
+    {file = "fonttools-4.41.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:381558eafffc1432d08ca58063e71c7376ecaae48e9318354a90a1049a644845"},
+    {file = "fonttools-4.41.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ee75b8ca48f6c48af25e967dce995ef94e46872b35c7d454b983c62c9c7006d"},
+    {file = "fonttools-4.41.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d45f28c20bb67dee0f4a4caae709f40b0693d764b7b2bf2d58890f36b1bfcef0"},
+    {file = "fonttools-4.41.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5448a87f6ed57ed844b64a05d3792827af584a8584613f6289867f4e77eb603b"},
+    {file = "fonttools-4.41.0-cp311-cp311-win32.whl", hash = "sha256:69dbe0154e15b68dd671441ea8f23dad87488b24a6e650d45958f4722819a443"},
+    {file = "fonttools-4.41.0-cp311-cp311-win_amd64.whl", hash = "sha256:ea879afd1d6189fca02a85a7868560c9bb8415dccff6b7ae6d81e4f06b3ab30d"},
+    {file = "fonttools-4.41.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8f602dd5bcde7e4241419924f23c6f0d66723dd5408a58c3a2f781745c693f45"},
+    {file = "fonttools-4.41.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:06eac087ea55b3ebb2207d93b5ac56c847163899f05f5a77e1910f688fe10030"},
+    {file = "fonttools-4.41.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e22d0144d735f6c7df770509b8c0c33414bf460df0d5dddc98a159e5dbb10eb"},
+    {file = "fonttools-4.41.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19d461c801b8904d201c6c38a99bfcfef673bfdfe0c7f026f582ef78896434e0"},
+    {file = "fonttools-4.41.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:72d40a32d6443871ea0d147813caad58394b48729dfa4fbc45dcaac54f9506f2"},
+    {file = "fonttools-4.41.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0614b6348866092d00df3dfb37e037fc06412ca67087de361a2777ea5ed62c16"},
+    {file = "fonttools-4.41.0-cp38-cp38-win32.whl", hash = "sha256:e43f6c7f9ba4f9d29edee530e45f9aa162872ec9549398b85971477a99f2a806"},
+    {file = "fonttools-4.41.0-cp38-cp38-win_amd64.whl", hash = "sha256:eb9dfa87152bd97019adc387b2f29ef6af601de4386f36570ca537ace96d96ed"},
+    {file = "fonttools-4.41.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d2dae84a3d0f76884a6102c62f2795b2d6602c2c95cfcce74c8a590b6200e533"},
+    {file = "fonttools-4.41.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cc3324e4159e6d1f55c3615b4c1c211f87cc96cc0cc7c946c8447dc1319f2e9d"},
+    {file = "fonttools-4.41.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c654b1facf1f3b742e4d9b2dcdf0fa867b1f007b1b4981cc58a75ef5dca2a3c"},
+    {file = "fonttools-4.41.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:560ea1a604c927399f36742abf342a4c5f3fee8e8e8a484b774dfe9630bd9a91"},
+    {file = "fonttools-4.41.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9387b09694fbf8ac7dcf887069068f81fb4124d05e09557ac7daabfbec1744bd"},
+    {file = "fonttools-4.41.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:465d0f24bf4f75160f441793b55076b7a080a57d3a1f738390af2c20bee24fbb"},
+    {file = "fonttools-4.41.0-cp39-cp39-win32.whl", hash = "sha256:841c491fa3e9c54e8f9cd5dae059e88f45e086aea090c28be9d42f59c8b99e01"},
+    {file = "fonttools-4.41.0-cp39-cp39-win_amd64.whl", hash = "sha256:efd59e83223cb77952997fb850c7a7c2a958c9af0642060f536722c2a9e9d53b"},
+    {file = "fonttools-4.41.0-py3-none-any.whl", hash = "sha256:5b1c2b21b40229166a864f2b0aec06d37f0a204066deb1734c93370e0c76339d"},
+    {file = "fonttools-4.41.0.tar.gz", hash = "sha256:6faff25991dec48f8cac882055a09ae1a29fd15bc160bc3d663e789e994664c2"},
 ]
 
 [package.extras]
@@ -1617,6 +1614,32 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.0.278"
+description = "An extremely fast Python linter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.278-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:1a90ebd8f2a554db1ee8d12b2f3aa575acbd310a02cd1a9295b3511a4874cf98"},
+    {file = "ruff-0.0.278-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:38ca1c0c8c1221fe64c0a66784c91501d09a8ed02a4dbfdc117c0ce32a81eefc"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c62a0bde4d20d087cabce2fa8b012d74c2e985da86d00fb3359880469b90e31"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7545bb037823cd63dca19280f75a523a68bd3e78e003de74609320d6822b5a52"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb380d2d6fdb60656a0b5fa78305535db513fc72ce11f4532cc1641204ef380"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d11149c7b186f224f2055e437a030cd83b164a43cc0211314c33ad1553ed9c4c"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:666e739fb2685277b879d493848afe6933e3be30d40f41fe0e571ad479d57d77"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ec8b0469b54315803aaf1fbf9a37162a3849424cab6182496f972ad56e0ea702"},
+    {file = "ruff-0.0.278-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c25b96602695a147d62a572865b753ef56aff1524abab13b9436724df30f9bd7"},
+    {file = "ruff-0.0.278-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a48621f5f372d5019662db5b3dbfc5f1450f927683d75f1153fe0ebf20eb9698"},
+    {file = "ruff-0.0.278-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1078125123a3c68e92463afacedb7e41b15ccafc09e510c6c755a23087afc8de"},
+    {file = "ruff-0.0.278-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3ce0d620e257b4cad16e2f0c103b2f43a07981668a3763380542e8a131d11537"},
+    {file = "ruff-0.0.278-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1cae4c07d334eb588f171f1363fa89a8911047eb93184276be11a24dbbc996c7"},
+    {file = "ruff-0.0.278-py3-none-win32.whl", hash = "sha256:70d39f5599d8449082ab8ce542fa98e16413145eb411dd1dc16575b44565d52d"},
+    {file = "ruff-0.0.278-py3-none-win_amd64.whl", hash = "sha256:e131595ab7f4ce61a1650463bd2fe304b49e7d0deb0dfa664b92817c97cdba5f"},
+    {file = "ruff-0.0.278-py3-none-win_arm64.whl", hash = "sha256:737a0cfb6c36aaa92d97a46957dfd5e55329299074ad06ed12663b98e0c6fc82"},
+    {file = "ruff-0.0.278.tar.gz", hash = "sha256:1a9f1d925204cfba81b18368b7ac943befcfccc3a41e170c91353b674c6b7a66"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.11.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -2100,18 +2123,18 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.16.0"
+version = "3.16.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.16.0-py3-none-any.whl", hash = "sha256:5dadc3ad0a1f825fe42ce1bce0f2fc5a13af2e6b2d386af5b0ff295bc0a287d3"},
-    {file = "zipp-3.16.0.tar.gz", hash = "sha256:1876cb065531855bbe83b6c489dcf69ecc28f1068d8e95959fe8bbc77774c941"},
+    {file = "zipp-3.16.2-py3-none-any.whl", hash = "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0"},
+    {file = "zipp-3.16.2.tar.gz", hash = "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
 all = ["Pillow", "PySide6", "glcontext", "matplotlib", "moderngl"]
@@ -2119,4 +2142,4 @@ all = ["Pillow", "PySide6", "glcontext", "matplotlib", "moderngl"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.12"
-content-hash = "afe4834838496e61065c2c1a552d409ca48075ba2f1d9b47b37c8102f9597aa5"
+content-hash = "fbf22e05ee004565f79d555c5517690f97b8b9d6f79d80a0335de54a8b212d96"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pytest-cov = ">=2.11.0"
 pytest-benchmark = ">=4.0.0"
 black = ">=22.3.0"
 isort = ">=5.8.0"
+ruff = ">=0.0.277"
 pyinstaller = ">=4.3"
 pyinstaller-hooks-contrib = ">=2022.3"  # fix for shapely 1.8.1
 packaging = ">=20.8"
@@ -131,9 +132,38 @@ exclude_lines = [
 
 [tool.black]
 line-length = 95
-target-version = ["py36", "py37", "py38"]
+target-version = ["py39", "py310", "py311"]
 
-[tool.isort]
-profile = "black"
-line_length = 95
-src_paths = ["vpype", "vpype_cli", "vpype_viewer", "tests"]
+[tool.ruff]
+line-length = 95
+target-version = "py39"
+select = [
+    "D",
+    "E",
+    "F",
+    "I",
+    "W",
+    "UP",
+]
+exclude = ["examples", "scripts"]
+ignore = [
+    "D1", # TODO: this should be applied on `vpype`
+
+    "D202",
+    "D203",
+    "D205",
+    "D213",
+    "D403",
+    "D415",
+]
+
+[tool.ruff.isort]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401", "F402", "F403"]
+"docs/conf.py" = ["D100", "D103"]
+"tests/*.py" = ["D209"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ pytest = ">=6.2.3"
 pytest-cov = ">=2.11.0"
 pytest-benchmark = ">=4.0.0"
 black = ">=22.3.0"
-isort = ">=5.8.0"
 ruff = ">=0.0.277"
 pyinstaller = ">=4.3"
 pyinstaller-hooks-contrib = ">=2022.3"  # fix for shapely 1.8.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import random
 import string
-import sys
 from typing import Callable, Protocol
 from xml.dom import minidom
 from xml.etree import ElementTree
@@ -225,7 +224,7 @@ def _write_reference_svg_fail_report(
 
 @pytest.fixture
 def reference_svg(request, tmp_path) -> Callable:
-    """Compare a SVG output to a saved reference.
+    """Compare an SVG output to a saved reference.
 
     Use `--store-ref-svg` to save reference SVGs.
 
@@ -235,9 +234,6 @@ def reference_svg(request, tmp_path) -> Callable:
             with reference_svg() as path:
                 export_svg_to(path)
     """
-
-    if sys.version_info < (3, 8):  # pragma: no cover
-        pytest.skip("requires Python 3.8 or higher")
 
     store_ref_svg = request.config.getoption("--store-ref-svg")
     test_id = "refsvg_" + hashlib.md5(request.node.name.encode()).hexdigest() + ".svg"
@@ -254,7 +250,7 @@ def reference_svg(request, tmp_path) -> Callable:
             ref_path.write_bytes(temp_file.read_bytes())
         else:
             if not ref_path.exists():  # pragma: no cover
-                pytest.fail(f"reference SVG does not exist")
+                pytest.fail("reference SVG does not exist")
 
             temp_lines = _read_svg_lines(temp_file)
             ref_lines = _read_svg_lines(ref_path)
@@ -272,6 +268,6 @@ def reference_svg(request, tmp_path) -> Callable:
 
                 _write_reference_svg_fail_report(ref_lines, temp_lines, request.node.name)
 
-                pytest.fail(f"generated SVG does not match reference:\n" + "\n".join(delta))
+                pytest.fail("generated SVG does not match reference:\n" + "\n".join(delta))
 
     return _reference_svg

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 import pytest
@@ -9,17 +11,17 @@ from .test_commands import EXAMPLE_SVG_DIR
 
 BLOCKS = [
     f"forfile '{EXAMPLE_SVG_DIR / '*.svg'}'",
-    f"forlayer",
-    f"grid -k 2 2",
-    f"repeat 3",
+    "forlayer",
+    "grid -k 2 2",
+    "repeat 3",
 ]
 
 
 @vpype_cli.cli.command()
 @vpype_cli.global_processor
 def doccopy(doc: vp.Document) -> vp.Document:
-    """This command has no effect on the pipeline, but creates completely new copies of the
-    pipeline's document and its content. This is useful to test the behaviour of blocks."""
+    # This command has no effect on the pipeline, but creates completely new copies of the
+    # pipeline's document and its content. This is useful to test the behaviour of blocks.
     return copy.deepcopy(doc)
 
 
@@ -65,7 +67,7 @@ def test_forlayer_vars():
         """
         repeat 5
             random -l new
-        end 
+        end
         eval 'cnt=0'
         forlayer
             eval 'assert _lid==cnt+1'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -470,7 +470,7 @@ def test_linesort_reject_bad_opt(runner):
     res = runner.invoke(
         cli,
         "line 0 0 0 10 line 0 10 10 10 line 0 0 10 0 line 10 0 10 10 "
-        f"linesort --no-flip dbsample dbdump",
+        "linesort --no-flip dbsample dbdump",
     )
 
     # in this situation, the greedy optimizer is worse than the starting position, so its

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import vpype as vp
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -146,7 +146,7 @@ def test_read_svg_width_height(params, expected, tmp_path):
 def test_read_with_viewbox(tmp_path):
     path = _write_svg_file(
         tmp_path,
-        f"""<?xml version="1.0"?>
+        """<?xml version="1.0"?>
     <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
        width="100" height="100" viewBox="50 50 10 10">
        <line x1="50" y1="50" x2="60" y2="60" />
@@ -162,10 +162,10 @@ def test_read_with_viewbox(tmp_path):
 
 
 def test_read_stdin(runner):
-    svg = f"""<?xml version="1.0"?>
+    svg = """<?xml version="1.0"?>
     <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
         width="1000" height="1000">
-      <circle cx="500" cy="500" r="40"/>      
+      <circle cx="500" cy="500" r="40"/>
     </svg>
     """
 
@@ -472,7 +472,7 @@ def test_read_stdin_sets_source_properties(monkeypatch):
     test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer.svg"
     monkeypatch.setattr("sys.stdin", io.StringIO(test_file.read_text()))
 
-    doc = vpype_cli.execute(f"read -")
+    doc = vpype_cli.execute("read -")
     assert vp.METADATA_FIELD_SOURCE not in doc.metadata
     assert doc.sources == set()
 
@@ -481,7 +481,7 @@ def test_read_single_layer_stdin_sets_source_properties(monkeypatch):
     test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer.svg"
     monkeypatch.setattr("sys.stdin", io.StringIO(test_file.read_text()))
 
-    doc = vpype_cli.execute(f"read -l1 -")
+    doc = vpype_cli.execute("read -l1 -")
     assert vp.METADATA_FIELD_SOURCE not in doc.metadata
     assert vp.METADATA_FIELD_SOURCE not in doc.layers[1].metadata
     assert doc.sources == set()
@@ -491,7 +491,7 @@ def test_read_by_attr_stdin_sets_source_properties(monkeypatch):
     test_file = TEST_FILE_DIRECTORY / "misc" / "multilayer.svg"
     monkeypatch.setattr("sys.stdin", io.StringIO(test_file.read_text()))
 
-    doc = vpype_cli.execute(f"read -a stroke -a fill -")
+    doc = vpype_cli.execute("read -a stroke -a fill -")
     assert vp.METADATA_FIELD_SOURCE not in doc.metadata
     assert doc.sources == set()
 
@@ -570,7 +570,7 @@ def test_read_command_page_size(
     if default[0] is not None and default[1] is not None:
         args += f"--display-size {default[0]:.3f}x{default[1]:.3f} "
         if default[0] > default[1]:
-            args += f"--display-landscape"
+            args += "--display-landscape"
     doc = vpype_cli.execute(f"read {args} '{path}'")
 
     assert doc.page_size == pytest.approx(target)
@@ -640,7 +640,7 @@ def test_read_layer_id_extraction():
     ],
 )
 def test_read_layer_id_from_svg(attr, exp):
-    svg = f"""<?xml version="1.0"?><svg width="500" height="300" 
+    svg = f"""<?xml version="1.0"?><svg width="500" height="300"
     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
         <g {attr}>
                 <line x1="0" y1="0" x2="10" y2="10" fill="red" />

--- a/tests/test_hpgl.py
+++ b/tests/test_hpgl.py
@@ -89,7 +89,7 @@ def simple_printer_config(config_file_factory):
         name = "simple"
         plotter_unit_length = 1
         pen_count = 2
-        
+
         [[device.simple.paper]]
         name = "simple"
         aka_names = ["aka_simple"]
@@ -98,7 +98,7 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 15]
         y_axis_up = false
         origin_location = [0, 0]
-        
+
         [[device.simple.paper]]
         name = "simple_landscape"
         paper_size = [15, 10]
@@ -106,7 +106,7 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 10]
         y_axis_up = false
         origin_location = [0, 0]
-        
+
         [[device.simple.paper]]
         name = "simple_y_up"
         paper_size = [10, 15]
@@ -114,7 +114,7 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 15]
         y_axis_up = true
         origin_location = [0, 15]
-        
+
         [[device.simple.paper]]
         name = "simple_ps10"
         paper_size = [10, 15]
@@ -123,7 +123,7 @@ def simple_printer_config(config_file_factory):
         y_axis_up = false
         origin_location = [0, 0]
         set_ps = 10
-        
+
         [[device.simple.paper]]
         name = "simple_rotate_180"
         paper_size = [10, 15]
@@ -132,7 +132,7 @@ def simple_printer_config(config_file_factory):
         y_axis_up = false
         origin_location = [0, 0]
         rotate_180 = true
-        
+
         [[device.simple.paper]]
         name = "simple_final_pu"
         paper_size = [10, 15]
@@ -141,7 +141,7 @@ def simple_printer_config(config_file_factory):
         y_axis_up = false
         origin_location = [0, 0]
         final_pu_params = "0,0"
-        
+
         [[device.simple.paper]]
         name = "simple_big"
         paper_size = [20, 30]
@@ -149,7 +149,7 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 30]
         y_axis_up = false
         origin_location = [0, 0]
-        
+
         [[device.simple.paper]]
         name = "simple_botleft"
         paper_size = [10, 15]
@@ -158,7 +158,7 @@ def simple_printer_config(config_file_factory):
         y_axis_up = true
         origin_location = [1, 1]
         origin_location_reference = "botleft"
-        
+
         # test flex paper size
         [[device.simple.paper]]
         name = "simple_flex_portrait"
@@ -166,25 +166,25 @@ def simple_printer_config(config_file_factory):
         y_axis_up = true
         origin_location = [1, 1]
         origin_location_reference = "botleft"
-        
+
         [[device.simple.paper]]
         name = "simple_flex_landscape"
         y_axis_up = true
         paper_orientation = "landscape"
         origin_location = [1, 1]
         origin_location_reference = "botleft"
-        
+
         [[device.simple.paper]]
         name = "simple_flex_portrait_implicit"
         y_axis_up = true
         origin_location = [1, 1]
         origin_location_reference = "botleft"
-        
+
         [device.double]
         name = "simple"
         plotter_unit_length = 0.5
         pen_count = 1
-        
+
         [[device.double.paper]]
         name = "simple"
         paper_size = [10, 15]
@@ -192,14 +192,14 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 30]
         y_axis_up = false
         origin_location = [0, 0]
-        
+
         # To test `info`.
         [device.info_device]
         name = "Info Device"
         info = "This is plotter information."
         plotter_unit_length = 0.5
         pen_count = 1
-        
+
         [[device.info_device.paper]]
         name = "simple"
         info = "This is paper information."
@@ -208,14 +208,14 @@ def simple_printer_config(config_file_factory):
         y_range = [0, 30]
         y_axis_up = false
         origin_location = [0, 0]
-        
+
         # To test failure modes
         [device.defective]
         name = "Defective Device"
         info = "This is plotter information."
         plotter_unit_length = 0.5
         pen_count = 1
-        
+
         [[device.defective.paper]]
         name = "wrong_ref"
         y_axis_up = false

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 import pytest
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import vpype as vp

--- a/vpype/__init__.py
+++ b/vpype/__init__.py
@@ -1,4 +1,5 @@
 """This module contains vpype core and its API."""
+from __future__ import annotations
 
 from .config import *
 from .filters import *

--- a/vpype/config.py
+++ b/vpype/config.py
@@ -181,7 +181,8 @@ class ConfigManager:
 
         def _update(d: dict, u: Mapping) -> dict:
             """This function must overwrite list member, UNLESS they are list of table, in
-            which case they must extend the list."""
+            which case they must extend the list.
+            """
             for k, v in u.items():
                 if isinstance(v, dict):
                     d[k] = _update(d.get(k, {}), v)

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -1,5 +1,5 @@
-"""File import/export functions.
-"""
+"""File import/export functions."""
+
 from __future__ import annotations
 
 import collections
@@ -10,7 +10,7 @@ import math
 import pathlib
 import re
 from collections.abc import Iterable, Iterator
-from typing import Any, List, TextIO, Union, cast
+from typing import Any, TextIO, Union, cast
 from xml.etree import ElementTree
 
 import click
@@ -980,7 +980,7 @@ def write_hpgl(
 
         # As per #310, we emit a single PU; between layers
         if not first_layer:
-            output.write(f"PU;")
+            output.write("PU;")
         else:
             first_layer = False
         output.write(f"SP{pen_id};")

--- a/vpype/metadata.py
+++ b/vpype/metadata.py
@@ -11,7 +11,6 @@ class Color:
     """Simple, immutable, hashable color class with flexible construction.
 
     Examples:
-
         >>> Color()
         Color(red=0, green=0, blue=0, alpha=255)
         >>> Color(255, 0, 255)

--- a/vpype/model.py
+++ b/vpype/model.py
@@ -1,11 +1,10 @@
-"""Implementation of vpype's data model
-"""
+"""Implementation of vpype's data model."""
 from __future__ import annotations
 
 import math
 import pathlib
 from collections.abc import Iterable, Iterator
-from typing import Any, Callable, Optional, Tuple, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 import numpy as np
 from shapely.geometry import LinearRing, LineString, MultiLineString
@@ -99,9 +98,8 @@ class _MetadataMixin:
 
 # noinspection PyShadowingNames
 class LineCollection(_MetadataMixin):
-    """
-    :py:class:`LineCollection` encapsulate a list of piecewise linear lines (or paths). Lines
-    are implemented as 1D numpy arrays of complex numbers whose real and imaginary parts
+    """:py:class:`LineCollection` encapsulate a list of piecewise linear lines (or paths).
+    Lines are implemented as 1D numpy arrays of complex numbers whose real and imaginary parts
     represent the X, respectively Y, coordinates of point in the paths.
 
     An instance of :py:class:`LineCollection` is used to model a single layer in vpype's
@@ -365,7 +363,7 @@ class LineCollection(_MetadataMixin):
             if np.hypot(delta.real, delta.imag) <= tolerance:
                 self._lines[i] = reloop(line)
 
-    def crop(self, x1: float, y1: float, x2: float, y2: float) -> None:
+    def crop(self, x1: float, y1: float, x2: float, y2: float) -> None:  # noqa: D417
         """Crop all lines to a rectangular area.
 
         Args:
@@ -412,7 +410,8 @@ class LineCollection(_MetadataMixin):
             line: np.ndarray, idx: int, *, reverse=False, prepend=False
         ) -> np.ndarray:
             """Append or prepend a line from the index to `line`, optionally reversing it
-            beforehand."""
+            beforehand.
+            """
             new_line = cast(np.ndarray, index.pop(idx))
             if reverse:
                 new_line = np.flip(new_line)
@@ -557,6 +556,8 @@ class Document(_MetadataMixin):
 
         Args:
             line_collection: if provided, used as layer 1
+            metadata: if provided, used as global metadata
+            page_size: if provided, used as page size
         """
         super().__init__(metadata)
 
@@ -605,6 +606,7 @@ class Document(_MetadataMixin):
     @property
     def layers(self) -> dict[int, LineCollection]:
         """Returns a reference to the layer dictionary.
+
         Returns:
             the internal layer dictionary
         """
@@ -772,7 +774,7 @@ class Document(_MetadataMixin):
         Args:
             lines: line data to assign to the layer
             layer_id: layer ID of the layer whose content is to be replaced
-            with_metadata:
+            with_metadata: if `True`, replace metadata as well
         """
 
         if layer_id not in self._layers:
@@ -845,7 +847,8 @@ class Document(_MetadataMixin):
         """Returns True if all layers are empty.
 
         Returns:
-            True if all layers are empty"""
+            True if all layers are empty
+        """
         for layer in self.layers.values():
             if not layer.is_empty():
                 return False
@@ -866,7 +869,8 @@ class Document(_MetadataMixin):
         """Returns the total number of layers.
 
         Returns:
-            total number of layer"""
+            total number of layer
+        """
         return len(self._layers.keys())
 
     def translate(self, dx: float, dy: float) -> None:
@@ -937,7 +941,7 @@ class Document(_MetadataMixin):
         else:
             return None
 
-    def crop(self, x1: float, y1: float, x2: float, y2: float) -> None:
+    def crop(self, x1: float, y1: float, x2: float, y2: float) -> None:  # noqa: D417
         """Crop all layers to a rectangular area.
 
         Args:

--- a/vpype/text.py
+++ b/vpype/text.py
@@ -1,5 +1,4 @@
-"""
-This code is adapted from https://github.com/fogleman/axi, which comes with the following
+"""This code is adapted from https://github.com/fogleman/axi, which comes with the following
 notice:
 
 Copyright (C) 2017 Michael Fogleman

--- a/vpype/utils.py
+++ b/vpype/utils.py
@@ -160,7 +160,6 @@ def convert_page_size(value: str) -> tuple[float, float]:
     a page size descriptor in the form of "WxH" where both W and H can have units.
 
     Examples:
-
         Using a know page size::
 
             >>> import vpype

--- a/vpype_cli/__init__.py
+++ b/vpype_cli/__init__.py
@@ -2,6 +2,8 @@
 function.
 """
 # register all commands
+from __future__ import annotations
+
 from .blocks import *
 from .cli import *
 from .debug import *

--- a/vpype_cli/__main__.py
+++ b/vpype_cli/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .cli import cli
 
 cli()

--- a/vpype_cli/blocks.py
+++ b/vpype_cli/blocks.py
@@ -44,7 +44,7 @@ def grid(
     offset: tuple[float, float],
     keep_page_size: bool,
 ) -> None:
-    """Creates a NX by NY grid of geometry
+    r"""Creates a NX by NY grid of geometry
 
     The number of column and row must always be specified. By default, 10mm offsets are used
     in both directions. Use the `--offset DX DY` option to override these values.
@@ -69,7 +69,6 @@ def grid(
         _i: current cell (0 to _n-1)
 
     Examples:
-
         Create a grid of random line patches:
 
             $ vpype begin grid 3 4 random end show
@@ -108,7 +107,7 @@ def grid(
 @click.argument("number", type=IntegerType(), metavar="N")
 @block_processor
 def repeat(state: State, processors: Iterable[ProcessorType], number: int) -> None:
-    """Repeat geometries N times.
+    r"""Repeat geometries N times.
 
     Repeats the enclosed command N times, stacking their output on top of each other.
 
@@ -124,7 +123,6 @@ def repeat(state: State, processors: Iterable[ProcessorType], number: int) -> No
         _i: counter (0 to N-1)
 
     Examples:
-
         Create a patch of random lines of 3 different colors:
 
             $ vpype begin repeat 3 random --layer %_i+1% end show
@@ -144,7 +142,7 @@ def repeat(state: State, processors: Iterable[ProcessorType], number: int) -> No
 @click.argument("files", type=TextType(), metavar="FILES")
 @block_processor
 def forfile(state: State, processors: Iterable[ProcessorType], files: str) -> None:
-    """Iterate over a file list.
+    r"""Iterate over a file list.
 
     The `forfile` block processor expends the FILES pattern into a file list like a shell
     would. In particular, wildcards (`*` and `**`) are expended, environmental variables are
@@ -168,7 +166,6 @@ def forfile(state: State, processors: Iterable[ProcessorType], files: str) -> No
         _i (int): counter (0 to _n-1)
 
     Example:
-
         Process all SVGs in the current directory:
 
     \b
@@ -226,7 +223,7 @@ class _MetadataProxy:
 @cli.command(group="Block processors")
 @block_processor
 def forlayer(state: State, processors: Iterable[ProcessorType]) -> None:
-    """Iterate over each layer.
+    r"""Iterate over each layer.
 
     This block processor execute the nested pipeline once per layer. The nested pipeline is
     exclusively exposed to the current layer. In addition, if the nested commands create any
@@ -244,7 +241,6 @@ def forlayer(state: State, processors: Iterable[ProcessorType]) -> None:
         _n (int): number of layers
 
     Example:
-
         Export one file per layer:
 
             vpype read input.svg forlayer write output_%_name%.svg end

--- a/vpype_cli/cli.py
+++ b/vpype_cli/cli.py
@@ -122,7 +122,9 @@ _PLUGINS_LOADED = False
 
 
 # noinspection PyUnusedLocal
-@click.group(cls=GroupedGroup, chain=True, invoke_without_command=True)
+@click.group(  # type: ignore[arg-type]
+    cls=GroupedGroup, chain=True, invoke_without_command=True
+)
 @click.version_option(version=vp.__version__, message="%(prog)s %(version)s")
 @click.option("-h", "--help", "help_flag", is_flag=True, help="Show this message and exit.")
 @click.option("-v", "--verbose", count=True)
@@ -447,7 +449,6 @@ def execute(
     returned as a :class:`vpype.Document` instance.
 
     Examples:
-
         Read an SVG file, optimize it and return the result as a :class:`vpype.Document`
         instance::
 

--- a/vpype_cli/debug.py
+++ b/vpype_cli/debug.py
@@ -1,6 +1,4 @@
-"""
-Hidden debug commands to help testing.
-"""
+"""Hidden debug commands to help testing."""
 from __future__ import annotations
 
 import json
@@ -22,9 +20,7 @@ __all__ = ("dbsample", "dbdump", "stat", "DebugData")
 @cli.command(hidden=True)
 @global_processor
 def dbsample(document: vp.Document):
-    """
-    Show statistics on the current geometries in JSON format.
-    """
+    """Show statistics on the current geometries in JSON format."""
     global debug_data
 
     data: dict[str, Any] = {}
@@ -55,14 +51,11 @@ def dbdump(document: vp.Document):
 
 
 class DebugData:
-    """
-    Helper class to load
-    """
+    """Helper class to load"""
 
     @staticmethod
     def load(debug_output: str):
-        """
-        Create DebugData instance array from debug output
+        """Create DebugData instance array from debug output
         :param debug_output:
         :return:
         """
@@ -82,8 +75,7 @@ class DebugData:
             )
 
     def bounds_within(self, x: float, y: float, width: float, height: float) -> bool:
-        """
-        Test if coordinates are inside. If `x` and `y` are provided only, consider input as
+        """Test if coordinates are inside. If `x` and `y` are provided only, consider input as
         a point. If `width` and `height` are passed as well, consider input as rect.
         """
         if self.count == 0:
@@ -154,14 +146,14 @@ def stat(document: vp.Document):
         print(f"  Path count: {len(layer)}")
         print(f"  Segment count: {layer.segment_count()}")
         print(
-            f"  Mean segment length:",
+            "  Mean segment length:",
             str(length / layer.segment_count() if layer.segment_count() else "n/a"),
         )
         print(f"  Bounds: {layer.bounds()}")
         print("  Properties:")
         for key, value in layer.metadata.items():
             print(f"    {key}: {value!r}")
-    print(f"Totals")
+    print("Totals")
     print(f"  Layer count: {len(document.layers)}")
     print(f"  Length: {length_tot}")
     print(f"  Pen-up length: {pen_up_length_tot}")
@@ -169,11 +161,11 @@ def stat(document: vp.Document):
     print(f"  Path count: {sum(len(layer) for layer in document.layers.values())}")
     print(f"  Segment count: {document.segment_count()}")
     print(
-        f"  Mean segment length:",
+        "  Mean segment length:",
         str(length_tot / document.segment_count() if document.segment_count() else "n/a"),
     )
     print(f"  Bounds: {document.bounds()}")
-    print(f"  Global properties:")
+    print("  Global properties:")
     for key, value in document.metadata.items():
         print(f"    {key}: {value!r}")
     print("========================= ")

--- a/vpype_cli/decorators.py
+++ b/vpype_cli/decorators.py
@@ -50,6 +50,7 @@ def layer_processor(f):
     Layer processors receive a :py:class:`LineCollection` as input and must return one.
 
     Example:
+
     .. code-block:: python3
 
         @click.command()
@@ -66,7 +67,7 @@ def layer_processor(f):
             return lines
 
         my_processor.help_group = "My Plugins"
-    """
+    """  # noqa: D412
 
     @click.option(
         "-l",

--- a/vpype_cli/decorators.py
+++ b/vpype_cli/decorators.py
@@ -50,7 +50,6 @@ def layer_processor(f):
     Layer processors receive a :py:class:`LineCollection` as input and must return one.
 
     Example:
-
     .. code-block:: python3
 
         @click.command()

--- a/vpype_cli/eval.py
+++ b/vpype_cli/eval.py
@@ -16,7 +16,7 @@ from .state import State
 @global_processor
 @pass_state
 def eval_cmd(state: State, document: vp.Document, expr: str):
-    """Evaluate an expression.
+    r"""Evaluate an expression.
 
     This command is a placeholder whose only purpose is to evaluate EXPR. It has no effect on
     the geometries, nor their properties. It is typically used at the beginning of a pipeline
@@ -26,7 +26,6 @@ def eval_cmd(state: State, document: vp.Document, expr: str):
     markers may be omitted.
 
     Example:
-
         Crop the geometry to a 1-cm margin.
 
     \b

--- a/vpype_cli/frames.py
+++ b/vpype_cli/frames.py
@@ -23,8 +23,7 @@ __all__ = ("frame",)
 @generator
 @pass_state
 def frame(state: State, offset: float):
-    """
-    Add a single-line frame around the geometry.
+    """Add a single-line frame around the geometry.
 
     By default, the frame shape is the current geometries' bounding box. An optional offset can
     be provided.

--- a/vpype_cli/generators.py
+++ b/vpype_cli/generators.py
@@ -26,8 +26,7 @@ __all__ = ("random",)
 )
 @generator
 def random(n: int, area: tuple[float, float]):
-    """
-    Generate random lines.
+    """Generate random lines.
 
     By default, 10 lines are randomly placed in a square with corners at (0, 0) and
     (10mm, 10mm). Use the `--area` option to specify the destination area.

--- a/vpype_cli/layerops.py
+++ b/vpype_cli/layerops.py
@@ -44,7 +44,6 @@ def lcopy(document, sources, dest, prob: float | None, no_prop: bool):
     properties with the same name. This behaviour can be disabled with the `--no-prop` option.
 
     Examples:
-
         Copy layer 1 to a new layer:
 
             vpype [...] lcopy 1 new [...]  # duplicate layer 1
@@ -117,7 +116,6 @@ def lmove(document, sources, dest, prob: float | None, no_prop: bool):
     properties with the same name. This behaviour can be disabled with the `--no-prop` option.
 
     Examples:
-
         Merge layer 1 and 2 to layer 1 (the content of layer 1 is not duplicated):
 
             vpype [...] lmove 1,2 1 [...]  # merge layer 1 and 2 to layer 1
@@ -271,7 +269,6 @@ def lreverse(document: vp.Document, layers) -> vp.Document:
     (to refer to every exising layers).
 
     Examples:
-
         Delete layer one:
 
             $ vpype [...] ldelete 1 [...]

--- a/vpype_cli/metadata.py
+++ b/vpype_cli/metadata.py
@@ -72,7 +72,7 @@ def propset(
     value: str,
     prop_type: str,
 ):
-    """Set the value of a global or layer property.
+    r"""Set the value of a global or layer property.
 
     Either the `--global` or `--layer` option must be used to specify whether a global or
     layer property should be set. When using `--layer`, either a single layer ID, a
@@ -95,7 +95,6 @@ def propset(
     names (red).
 
     Examples:
-
         Set a global property of type `int`:
 
             vpype [...] propset --global --type int my_prop 10 [...]
@@ -145,7 +144,6 @@ def proplist(document: vp.Document, global_flag: bool, layer: int | list[int] | 
     coma-separated list of layer ID, or `all` may be used.
 
     Examples:
-
         Print a list of global properties:
 
             vpype pagesize a4 proplist -g
@@ -181,7 +179,6 @@ def propget(
     coma-separated list of layer ID, or `all` may be used.
 
     Examples:
-
         Print the value of property `vp_color` for all layers:
 
             vpype [...] pens cmyk propget --layer all vp_color [...]
@@ -215,7 +212,6 @@ def propdel(
     coma-separated list of layer ID, or `all` may be used.
 
     Examples:
-
         Remove a property from a layer:
 
             vpype [...] pens cmyk propdel --layer 1 vp_name [...]
@@ -243,7 +239,6 @@ def propclear(document: vp.Document, global_flag: bool, layer: int | list[int] |
     coma-separated list of layer ID, or `all` may be used.
 
     Examples:
-
         Remove all global properties:
 
             vpype [...] propclear --global [...]
@@ -273,7 +268,6 @@ def penwidth(layer: vp.LineCollection, pen_width: float) -> vp.LineCollection:
     set the pen width of one (or more) specific layer(s).
 
     Examples:
-
         Set the pen width for all layers:
 
             $ vpype [...] penwidth 0.15mm [...]
@@ -303,7 +297,6 @@ def color(layer: vp.LineCollection, color: str) -> vp.LineCollection:
     command.
 
     Examples:
-
         Set the color for all layers:
 
             $ vpype [...] color red [...]
@@ -331,7 +324,6 @@ def alpha(layer: vp.LineCollection, alpha: float) -> vp.LineCollection:
     more target layer(s)
 
     Examples:
-
         Set all layer to 50% red:
 
             $ vpype [...] color red alpha .5 [...]
@@ -360,7 +352,6 @@ def name(layer: vp.LineCollection, name: str) -> vp.LineCollection:
     the name of one (or more) specific layer(s).
 
     Examples:
-
         Set the name for a specific layer:
 
             $ vpype [...] name --layer 4 black [...]

--- a/vpype_cli/operations.py
+++ b/vpype_cli/operations.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import List, Optional, Union, cast
+from typing import cast
 
 import click
 import numpy as np
 
 import vpype as vp
-from vpype.geometry import line_length
-from vpype.model import LineCollection
 
 from .cli import cli
 from .decorators import global_processor, layer_processor
@@ -110,8 +108,7 @@ def trim(
 )
 @layer_processor
 def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
-    """
-    Merge lines whose endings and starts overlap or are very close.
+    """Merge lines whose endings and starts overlap or are very close.
 
     By default, `linemerge` considers both directions of a stroke. If there is no additional
     start of a stroke within the provided tolerance, it also checks for ending points of
@@ -148,8 +145,7 @@ def linemerge(lines: vp.LineCollection, tolerance: float, no_flip: bool = True):
 )
 @layer_processor
 def linesort(lines: vp.LineCollection, no_flip: bool, two_opt: bool, passes: int):
-    """
-    Sort lines to minimize the pen-up travel distance.
+    """Sort lines to minimize the pen-up travel distance.
 
     This command reorders the paths within layers such as to minimize the total pen-up
     distance. By default, it will also invert the path direction if it can further optimize the
@@ -304,8 +300,7 @@ def linesort(lines: vp.LineCollection, no_flip: bool, two_opt: bool, passes: int
 )
 @layer_processor
 def linesimplify(lines: vp.LineCollection, tolerance):
-    """
-    Reduce the number of segments in the geometries.
+    """Reduce the number of segments in the geometries.
 
     The resulting geometries' points will be at a maximum distance from the original controlled
     by the `--tolerance` parameter (0.05mm by default).
@@ -361,8 +356,7 @@ def reloop(lines: vp.LineCollection, tolerance):
 )
 @layer_processor
 def multipass(lines: vp.LineCollection, count: int):
-    """
-    Add multiple passes to each line
+    """Add multiple passes to each line
 
     Each line is extended with a mirrored copy of itself, optionally multiple times. This is
     useful for pens that need several passes to ensure a good quality.
@@ -384,8 +378,7 @@ def multipass(lines: vp.LineCollection, count: int):
 @cli.command(group="Operations")
 @layer_processor
 def splitall(lines: vp.LineCollection) -> vp.LineCollection:
-    """
-    Split all paths into their constituent segments.
+    """Split all paths into their constituent segments.
 
     This command may be used together with `linemerge` for cases such as densely-connected
     meshes where the latter cannot optimize well enough by itself. This command will
@@ -488,7 +481,6 @@ def pagesize(document: vp.Document, size, landscape) -> vp.Document:
     geometries.
 
     Examples:
-
         Set the page size to A4:
 
             vpype [...] pagesize a4 [...]
@@ -538,7 +530,7 @@ geometries. If `--fit-to-margins` is used, the page size is increased to accommo
 margin. By construction, `--align` and `--valign` have no effect with `tight`.
 
 On an empty pipeline, `layout` simply sets the page size to SIZE, unless `tight` is used. In
-this case, `layout` has no effect at all.   
+this case, `layout` has no effect at all.
 
 Examples:
 
@@ -547,9 +539,9 @@ Examples:
     pleasing arrangement for square designs on portrait-oriented pages):
 
         vpype read input.svg layout --fit-to-margins 3cm --valign top a4 write output.svg
-        
+
     Set the page size to the geometries' boundary, with a 1cm margin:
-    
+
         vpype read input.svg layout --fit-to-margins 3cm tight write output.svg
 """
 
@@ -683,7 +675,6 @@ def snap(line_collection: vp.LineCollection, pitch: float) -> vp.LineCollection:
     path contains less than 2 points, it is discarded.
 
     Example:
-
         Snap all points to a grid of 3x3mm:
 
             vpype [...] snap 3mm [...]

--- a/vpype_cli/primitives.py
+++ b/vpype_cli/primitives.py
@@ -59,7 +59,6 @@ def rect(
     The rectangle is defined by its top left corner (X, Y) and its width and height.
 
     Examples:
-
         Straight-angle rectangle:
 
             vpype rect 10cm 10cm 3cm 2cm show

--- a/vpype_cli/read.py
+++ b/vpype_cli/read.py
@@ -155,7 +155,6 @@ of appearance.
     `write` command can optionally restore them in the exported SVG.
 
     Examples:
-
         Multi-layer SVG import:
 
             vpype read input_file.svg [...]

--- a/vpype_cli/script.py
+++ b/vpype_cli/script.py
@@ -16,8 +16,7 @@ __all__ = ("script",)
 @click.argument("file", type=click.Path(exists=True, dir_okay=False))
 @generator
 def script(file) -> vp.LineCollection:
-    """
-    Call an external python script to generate geometries.
+    """Call an external python script to generate geometries.
 
     The script must contain a `generate()` function which will be called without arguments. It
     must return the generated geometries in one of the following format:
@@ -36,7 +35,7 @@ def script(file) -> vp.LineCollection:
             raise FileNotFoundError(f"file {file} not found")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)  # type: ignore
-        return LineCollection(module.generate())  # type: ignore
+        return vp.LineCollection(module.generate())  # type: ignore
     except Exception as exc:
         raise click.ClickException(
             f"the file path must point to a Python script containing a `generate()`"

--- a/vpype_cli/state.py
+++ b/vpype_cli/state.py
@@ -39,7 +39,8 @@ class _DeferredEvaluator(ABC):
     @abstractmethod
     def evaluate(self, state: State) -> Any:
         """Sub-class must override this function and return the converted value of
-        ``self._text``"""
+        ``self._text``
+        """
 
     def __str__(self):
         return self._text

--- a/vpype_cli/transforms.py
+++ b/vpype_cli/transforms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Tuple, cast
+from typing import cast
 
 import click
 
@@ -42,8 +42,7 @@ def _compute_origin(
 @click.argument("offset", nargs=2, type=LengthType(), required=True)
 @layer_processor
 def translate(lc: vp.LineCollection, offset: tuple[float, float]):
-    """
-    Translate the geometries. X and Y offsets must be provided. These arguments understand
+    """Translate the geometries. X and Y offsets must be provided. These arguments understand
     supported units.
 
     Note: negative offsets are possible, but the end-of-options marker `--` must be used to
@@ -51,7 +50,6 @@ def translate(lc: vp.LineCollection, offset: tuple[float, float]):
     example below).
 
     Examples:
-
         Translate layer 2 by 2cm rightward and 3cm downward:
 
             vpype [...] translate -l 2 2cm 3cm [...]
@@ -101,7 +99,6 @@ def scale_relative(
     to disambiguate the minus sign, which would normally be interpreted as a command option.
 
     Example:
-
         Double the size of the geometries in layer 1, using (0, 0) as origin:
 
             vpype [...] scale -l 1 -o 0 0 2 2 [...]
@@ -168,8 +165,7 @@ def scaleto(
     listed layers.
 
     Example:
-
-        Scale a SVG to a A4 page, accounting for 1cm margin:
+        Scale an SVG to a A4 page, accounting for 1cm margin:
 
             vpype read input.svg scaleto 19cm 27.7cm write -p a4 -c output.svg
 

--- a/vpype_cli/write.py
+++ b/vpype_cli/write.py
@@ -51,7 +51,7 @@ Layers are labelled with their numbers by default. If an alternative naming is r
 template pattern can be provided using the `--layer-label` option. The provided pattern must
 contain a C-style format specifier such as `%d` which will be replaced by the layer number.
 
-By default, paths are colored according to the corresponding layer property (as set by the 
+By default, paths are colored according to the corresponding layer property (as set by the
 `color` or `read` commands). If the color property is not set, a default, per-layer color
 scheme is used. Alternative behaviours are available with the `--color-mode` option. Setting it
 to "none" disables coloring and black paths are generated. Setting it to "layer" applies the
@@ -125,7 +125,7 @@ Examples:
 """
 
 
-@cli.command(group="Output", help=WRITE_HELP)
+@cli.command(group="Output", help=WRITE_HELP)  # type: ignore[arg-type]
 @click.argument("output", type=FileType("w"))
 @click.option(
     "-f",

--- a/vpype_viewer/__init__.py
+++ b/vpype_viewer/__init__.py
@@ -2,6 +2,8 @@
 rendering of :class:`vpype.Document` instances. It includes a Qt-based interactive backend as
 well as a Pillow-based offscreen rendering backend.
 """
+from __future__ import annotations
+
 from ._scales import DEFAULT_SCALE_SPEC, UnitType
 from .engine import *
 from .image import ImageRenderer, render_image

--- a/vpype_viewer/_painters.py
+++ b/vpype_viewer/_painters.py
@@ -202,11 +202,11 @@ class LineCollectionPointsPainter(Painter):
 
         vertex = """
             #version 330
-            
+
             uniform mat4 projection;
-            
+
             in vec2 position;
-            
+
             void main() {
               gl_PointSize = 5.0;
               gl_Position = projection * vec4(position, 0.0, 1.0);
@@ -215,11 +215,11 @@ class LineCollectionPointsPainter(Painter):
 
         fragment = """
             #version 330
-            
+
             uniform vec4 color;
-            
+
             out vec4 out_color;
-            
+
             void main() {
                out_color = color;
             }
@@ -323,7 +323,8 @@ class LineCollectionPreviewPainter(Painter):
     @staticmethod
     def _build_buffers(lc: vp.LineCollection):
         """Prepare the buffers for multi-polyline rendering. Closed polyline must have their
-        last point identical to their first point."""
+        last point identical to their first point.
+        """
 
         indices = []
         reset_index = np.array([-1])

--- a/vpype_viewer/_utils.py
+++ b/vpype_viewer/_utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
 import pathlib
-from typing import Any, Dict, Tuple, cast
+from typing import Any, cast
 
 import cachetools
 import cachetools.keys

--- a/vpype_viewer/engine.py
+++ b/vpype_viewer/engine.py
@@ -1,6 +1,4 @@
-"""
-Generic viewer
-"""
+"""Generic viewer."""
 from __future__ import annotations
 
 import enum
@@ -147,7 +145,8 @@ class Engine:
     @property
     def origin(self) -> tuple[float, float]:
         """Current origin (document coordinates corresponding to the display window's top-left
-        corner."""
+        corner.
+        """
         return self._origin
 
     @origin.setter
@@ -301,7 +300,8 @@ class Engine:
 
     def fit_to_viewport(self):
         """Fit the current document in the viewport, allowing for a 2.5% margin on either
-        sides."""
+        sides.
+        """
         if self._document is None:
             return
 
@@ -339,6 +339,7 @@ class Engine:
 
     def resize(self, width: int, height: int) -> None:
         """Resizes the viewport.
+
         Args:
             width: new viewport width
             height: new viewport height
@@ -435,7 +436,6 @@ class Engine:
             self._rulers_painter.render(self, proj)
 
     def _update(self, rebuild=True):
-        """"""
         if rebuild:
             self._rebuild_needed = True
         self._render_cb()

--- a/vpype_viewer/image/__init__.py
+++ b/vpype_viewer/image/__init__.py
@@ -13,7 +13,6 @@ class ImageRenderer:
     """Viewer engine wrapper class to render to a :class:`PIL.Image.Image` instance.
 
     Example:
-
         >>> doc = vp.Document()
         # populate doc
         >>> renderer = ImageRenderer((640, 480))

--- a/vpype_viewer/qtviewer/__init__.py
+++ b/vpype_viewer/qtviewer/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def _check_wayland():
     """Fix QT env variable on Wayland-based systems.
 
@@ -15,4 +18,4 @@ def _check_wayland():
 _check_wayland()
 
 
-from .viewer import *
+from .viewer import *  # noqa: E402

--- a/vpype_viewer/qtviewer/utils.py
+++ b/vpype_viewer/qtviewer/utils.py
@@ -19,7 +19,7 @@ def load_icon(path: str) -> QIcon:
     app = QGuiApplication.instance()
 
     if app is None or not isinstance(app, QGuiApplication):
-        raise EnvironmentError("no Qt application available")
+        raise RuntimeError("no Qt application available")
 
     base_color = app.palette().color(QPalette.ColorRole.Base)
     if base_color.lightnessF() < 0.5:

--- a/vpype_viewer/qtviewer/viewer.py
+++ b/vpype_viewer/qtviewer/viewer.py
@@ -1,6 +1,4 @@
-"""
-Qt Viewer
-"""
+"""Qt Viewer."""
 from __future__ import annotations
 
 import functools
@@ -64,12 +62,14 @@ QSurfaceFormat.setDefaultFormat(default_format)
 
 class QtViewerWidget(QOpenGLWidget):
     """QGLWidget wrapper around :class:`Engine` to display a :class:`vpype.Document` in
-    Qt GUI."""
+    Qt GUI.
+    """
 
     mouse_coords = Signal(str)
 
     def __init__(self, document: vp.Document | None = None, parent=None):
         """Constructor.
+
         Args:
             document: the document to display
             parent: QWidget parent
@@ -238,8 +238,9 @@ class QtViewerWidget(QOpenGLWidget):
 
 
 class QtViewer(QWidget):
-    """Full featured, stand-alone viewer suitable for displaying a :class:`vpype.Document` to
-    a user."""
+    """Full-featured, stand-alone viewer suitable for displaying a :class:`vpype.Document` to
+    a user.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
#### Description

Use Ruff, deprecate sort.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `isort`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
