### PR TITLE
Added support for Python 3.12 and dropped support for Python 3.9

### DIFF
--- a/.github/workflows/python-lint-tests.yml
+++ b/.github/workflows/python-lint-tests.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, '3.10', '3.11']
-        os: [ubuntu-latest, macos-latest, windows-latest, self-hosted]
+        python-version: ['3.10', '3.11', '3.12']
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         shell: bash
@@ -36,7 +36,7 @@ jobs:
     - name: Install project
       run: poetry install -E all
     - name: Lint and static analysis
-      if:  matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'  # no need to run that 9x
+      if:  matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'  # no need to run that 9x
       run: |
         poetry run ruff check --show-source vpype vpype_cli vpype_viewer tests
         poetry run black --check --diff vpype vpype_cli vpype_viewer tests
@@ -53,15 +53,15 @@ jobs:
     - name: Pytest (code coverage)
       run: |
         poetry run pytest --cov=./ --cov-report=xml
-      if: (matrix.os == 'macos-latest' || matrix.os == 'self-hosted') && matrix.python-version == '3.11'
+      if: matrix.os == 'macos-latest' && matrix.python-version == '3.12'
     - name: Pytest
       run: |
         poetry run pytest
-      if: (matrix.os == 'macos-latest' || matrix.os == 'self-hosted') && matrix.python-version != '3.11'
+      if: matrix.os == 'macos-latest' && matrix.python-version != '3.12'
     - name: Pytest (no image similarity check)
       run: |
         poetry run pytest --skip-image-similarity
-      if: matrix.os != 'macos-latest' && matrix.os != 'self-hosted'
+      if: matrix.os != 'macos-latest'
     - name: Upload comparison test results
       if: failure()
       uses: actions/upload-artifact@v3
@@ -76,7 +76,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'macos-latest' && matrix.python-version == '3.11'
+      if: matrix.os == 'macos-latest' && matrix.python-version == '3.12'
 
 
   # ----------------------------------------
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'poetry'
     - name: Install project
       run: poetry install -E all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         # no caching!
     - name: Install project
       run: poetry install -E all
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Build artifacts
         run: poetry build
       - name: Publish to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Release date: UNRELEASED
 
 ### New features and improvements
 
+* Added support for Python 3.12 and dropped support for Python 3.9 (#681)
 * Added an option to the `reverse` command to also flip the line direction (#654)
-* Added a `--hyphenate LANG` option to the `text` command (#668)
+* Added a `--hyphenate LANG` option to the `text` command (thanks to @pepijndevos) (#668)
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ curvy (circles, bezier curves, etc.) to lines made of small segments. _vpype_ do
 Detailed installation instructions are available in the [latest documentation](https://vpype.readthedocs.io/en/latest/install.html).
 
 TL;DR:
-- Python 3.10 is recommended, but *vpype* is also compatible with Python 3.8 and 3.9. 
+- Python 3.12 is recommended, but *vpype* is also compatible with Python 3.10 and 3.11. 
 - *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed using [pipx](https://pypa.github.io/pipx/):
   ```bash
   pipx install "vpype[all]"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,11 +9,11 @@ This page explain how to install *vpype* for end-users. If you intend to develop
 
 .. note::
 
-  The recommended Python version is 3.10.2 or later. *vpype* is also compatible with Python 3.8 and 3.9.
+  The recommended Python version is 3.12.1 or later. *vpype* is also compatible with Python 3.10 and 3.11.
 
 .. warning::
 
-  *vpype* is not yet compatible with Python 3.11.
+  *vpype* is not yet compatible with Python 3.13.
 
 
 macOS
@@ -38,7 +38,7 @@ You can  ensure that the installed Python interpreter is properly installed by r
 
 It should produce an output similar to::
 
-  Python 3.10.8
+  Python 3.12.1
 
 The version number should match the installer you used.
 
@@ -59,7 +59,7 @@ After this, restart your terminal and ensure that pipx is properly installed by 
 
 It should print out the current version of pipx without error::
 
-  1.1.0
+  1.2.0
 
 
 Installing *vpype*

--- a/poetry.lock
+++ b/poetry.lock
@@ -627,43 +627,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "7.0.1"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
-    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
-]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
-
-[[package]]
-name = "importlib-resources"
-version = "6.1.1"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.1.1-py3-none-any.whl", hash = "sha256:e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"},
-    {file = "importlib_resources-6.1.1.tar.gz", hash = "sha256:3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "zipp (>=3.17)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -957,7 +920,6 @@ files = [
 contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.3.1"
 numpy = ">=1.21,<2"
 packaging = ">=20.0"
@@ -1434,7 +1396,6 @@ files = [
 
 [package.dependencies]
 altgraph = "*"
-importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
 packaging = ">=22.0"
 pefile = {version = ">=2022.5.30", markers = "sys_platform == \"win32\""}
@@ -1458,7 +1419,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 packaging = ">=22.0"
 setuptools = ">=42.0.0"
 
@@ -1922,7 +1882,6 @@ babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.18.1,<0.21"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
 packaging = ">=21.0"
 Pygments = ">=2.14"
@@ -2246,25 +2205,10 @@ brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
-[[package]]
-name = "zipp"
-version = "3.17.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
-    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
 [extras]
 all = ["Pillow", "PySide6", "glcontext", "matplotlib", "moderngl"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9, <3.12"
-content-hash = "243713c9958bccaada6645b8ddb6cd2aa25c96912b0f9efe73abf4a3408ea8ff"
+python-versions = ">=3.10, <3.13"
+content-hash = "5916aa6151109ee3577b75516376f3c760e788597f93cda247dec731bada0303"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = [
 vpype = "vpype_cli.cli:cli"
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.12"
+python = ">=3.10, <3.13"
 
 asteval = ">=0.9.26"
 cachetools = ">=4.2.2"


### PR DESCRIPTION
#### Description

- Add support for Python 3.12
- Remove support for Python 3.9
- Remove spurious `self-hosted` stuff from CI

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `ruff check .`)
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [x] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
