### PR TITLE
Fixed CLI help for the `lreverse` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release date: UNRELEASED
 ### Bug fixes
 
 * Fixed issue with ImageRenderer where the GL context wasn't released, ultimately causing a crash when running the test suite (which could involve many hundreds of context creation) (#616)
+* Fixed CLI help for the lreverse command (#683)
 
 ### Other changes
 

--- a/vpype_cli/layerops.py
+++ b/vpype_cli/layerops.py
@@ -269,17 +269,10 @@ def lreverse(document: vp.Document, layers) -> vp.Document:
     (to refer to every exising layers).
 
     Examples:
-        Delete layer one:
 
-            $ vpype [...] ldelete 1 [...]
+        Reverse path order in layer 1:
 
-        Delete layers 1 and 2:
-
-            $ vpype [...] ldelete 1,2 [...]
-
-        Delete all layers:
-
-            $ vpype [...] ldelete all [...]
+            $ vpype [...] lreverse 1 [...]
     """
 
     lids = set(multiple_to_layer_ids(layers, document))

--- a/vpype_cli/layerops.py
+++ b/vpype_cli/layerops.py
@@ -269,7 +269,6 @@ def lreverse(document: vp.Document, layers) -> vp.Document:
     (to refer to every exising layers).
 
     Examples:
-
         Reverse path order in layer 1:
 
             $ vpype [...] lreverse 1 [...]


### PR DESCRIPTION
#### Description

Fixed CLI help for the `lreverse` command

* Fixes #679

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `ruff check .`)
- [x] `mypy` returns no error
- [ ] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
