### PR TITLE
Fix crash when reading SVG with simplify active (`read --simplify` or using the read APIs with `simplify=True`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* ...
+* Fixed a crash when reading SVG with simplify active (via the `read --simplify` command or the read APIs with `simplify=True`) (thanks to @nataquinones) (#732)
 
 
 ## 1.14

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -43,6 +43,7 @@ MINIMAL_COMMANDS = [
     Command("circle 0 0 1"),
     Command("ellipse 0 0 2 4"),
     Command(f"read '{EXAMPLE_SVG}'", preserves_metadata=False),
+    Command(f"read -s '{EXAMPLE_SVG}'", preserves_metadata=False),
     Command(f"read -m '{EXAMPLE_SVG}'", preserves_metadata=False),
     Command(f"read -a stroke '{EXAMPLE_SVG}'", preserves_metadata=False),
     Command("write -f svg -"),

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -336,7 +336,8 @@ def _flattened_paths_to_line_collection(
                 line = seg.npoint(np.linspace(0, 1, step))
 
                 if simplify:
-                    line = np.array(LineString(line).simplify(tolerance=quantization))
+                    line = LineString(line).simplify(tolerance=quantization)
+                    line = np.array(line.coords, dtype=float)
 
                 line = line.view(dtype=complex).reshape(len(line))
 


### PR DESCRIPTION
#### Description
Separated LineString simplification and numpy array conversion to fix TypeError caused by changing data-type for object array.

#### Checklist

- [x] feature/fix implemented
- [x] code formatting ok (`black` and `ruff check .`)
- [x] `mypy` returns no error
- [x] tests added/updated and `pytest` succeeds
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [x] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [ ] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
