### PR TITLE
Add htmlzip export format for docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+formats:
+  - htmlzip
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ version: 2
 
 formats:
   - htmlzip
+  - pdf
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
#### Description

Basically title.
Can't check if this works locally, as `just docs-live` doesn't show the bottom-right menu with version selection and doc export options (which is visible in the hosted docs https://vpype.readthedocs.io/en/latest/).

#### Checklist

- [ ] feature/fix implemented
- [ ] code formatting and`mypy` ok (`just lint`)
- [ ] tests added/updated and `pytest` succeeds (`just test`)
- [x] documentation added/updated
    - [ ] command docstring and option/argument `help`
    - [ ] README.md updated (Feature Overview)
    - [ ] CHANGELOG.md updated
    - [ ] added new command to `reference.rst`
    - [x] RTD doc updated and building with no error (`make clean && make html` in `docs/`)
