### PR TITLE
fix: correct 'Imperal' -> 'Imperial' typo in vpype_config.toml

### DIFF
--- a/vpype/vpype_config.toml
+++ b/vpype/vpype_config.toml
@@ -54,7 +54,7 @@ set_ps = 0
 [[device.hp7475a.paper]]
 name = "a"
 aka_names = ["ansi_a", "letter"]
-info = "The plotter must be configured in Imperal mode."
+info = "The plotter must be configured in Imperial mode."
 paper_size = ["11in", "8.5in"]
 x_range = [0, 10365]
 y_range = [0, 7962]
@@ -66,7 +66,7 @@ set_ps = 4
 [[device.hp7475a.paper]]
 name = "b"
 aka_names = ["ansi_b", "tabloid"]
-info = "The plotter must be configured in Imperal mode."
+info = "The plotter must be configured in Imperial mode."
 paper_size = ["17in", "11in"]
 x_range = [0, 16640]
 y_range = [0, 10365]
@@ -294,7 +294,7 @@ set_ps = 0
 [[device.hp7550.paper]]
 name = "a"
 aka_names = ["ansi_a", "letter", "A"]
-info = "The plotter must be configured in Imperal mode."
+info = "The plotter must be configured in Imperial mode."
 paper_size = ["11in", "8.5in"]
 x_range = [0, 10170]
 y_range = [0, 7840]
@@ -306,7 +306,7 @@ set_ps = 4
 [[device.hp7550.paper]]
 name = "b"
 aka_names = ["ansi_b", "tabloid", "B"]
-info = "The plotter must be configured in Imperal mode."
+info = "The plotter must be configured in Imperial mode."
 paper_size = ["17in", "11in"]
 x_range = [0, 16540]
 y_range = [0, 10170]


### PR DESCRIPTION
## 概要

#845 で報告されている `vpype/vpype_config.toml` の `Imperal` typo を `Imperial` に修正します。

対象:

- L57(`device.hp7475a.paper` name = `"a"` / `ansi_a, letter`)
- L69(`device.hp7475a.paper` name = `"b"` / `ansi_b, tabloid`)
- L297(`device.hp7550.paper` name = `"a"` / `ansi_a, letter, A`)
- L309(`device.hp7550.paper` name = `"b"` / `ansi_b, tabloid, B`)

いずれも同一文字列 `"The plotter must be configured in Imperal mode."` で、HP7475A / HP7550 の 2 デバイス x a / b の 2 用紙サイズ = 4 箇所が同じ typo を繰り返している形でした。

Closes #845

## 動作確認

- `git diff` で 4 行のみ変更、他の `paper_size` / `x_range` / `y_range` 等の数値・他 device セクションは無変更
- `grep -c "Imperal" vpype/vpype_config.toml` = `0`、`grep -c "Imperial"` = `4`
- `python -c "import tomllib; tomllib.load(open('vpype/vpype_config.toml','rb'))"` でパース OK(構文崩れ無し)
- gitleaks v8.30.1 でスキャン clean