### PR TITLE
Recommend `uv tool` for installation instead of pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,24 +192,25 @@ TL;DR:
 - *vpype* is compatible with Python 3.11, 3.12, and 3.13.
 - *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed with [`uv tool`](https://docs.astral.sh/uv/guides/tools/) (install `uv` itself by following the [official `uv` installation instructions](https://docs.astral.sh/uv/getting-started/installation/)).
 - `uv` will download a suitable managed Python interpreter automatically, so you do not need to install Python first.
+- The commands below pass `--python 3.13` explicitly. Without it, `uv` will pick Python 3.14, which currently fails because [ModernGL](https://pypi.org/project/moderngl/) (a viewer dependency) does not yet publish 3.14 wheels. Python 3.13 is the latest version for which all viewer dependencies ship pre-built wheels.
 - The package name to install is `vpype[all]`. Quoting rules depend on the shell:
   - **macOS / Linux (bash, zsh):**
     ```bash
-    uv tool install "vpype[all]"
+    uv tool install --python 3.13 "vpype[all]"
     ```
   - **Windows (cmd.exe):**
     ```bat
-    uv tool install vpype[all]
+    uv tool install --python 3.13 vpype[all]
     ```
   - **Windows (PowerShell):**
     ```powershell
-    uv tool install "vpype[all]"
+    uv tool install --python 3.13 "vpype[all]"
     ```
 - A CLI-only version of *vpype* can be installed using the following command (no quoting needed since there are no square brackets):
   ```bash
   uv tool install vpype
   ```
-  This version does not include the [`show`](https://vpype.readthedocs.io/en/latest/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide6, and ModernGL).
+  This version does not include the [`show`](https://vpype.readthedocs.io/en/latest/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide6, and ModernGL). Because none of the lagging-wheel dependencies are involved, the `--python 3.13` flag is not needed.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -189,14 +189,25 @@ curvy (circles, bezier curves, etc.) to lines made of small segments. _vpype_ do
 Detailed installation instructions are available in the [latest documentation](https://vpype.readthedocs.io/en/latest/install.html).
 
 TL;DR:
-- Python 3.13 is recommended, but *vpype* is also compatible with Python 3.11 and 3.12. 
-- *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed using [pipx](https://pypa.github.io/pipx/):
+- *vpype* is compatible with Python 3.11, 3.12, and 3.13.
+- *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed with [`uv tool`](https://docs.astral.sh/uv/guides/tools/) (install `uv` itself by following the [official `uv` installation instructions](https://docs.astral.sh/uv/getting-started/installation/)).
+- `uv` will download a suitable managed Python interpreter automatically, so you do not need to install Python first.
+- The package name to install is `vpype[all]`. Quoting rules depend on the shell:
+  - **macOS / Linux (bash, zsh):**
+    ```bash
+    uv tool install "vpype[all]"
+    ```
+  - **Windows (cmd.exe):**
+    ```bat
+    uv tool install vpype[all]
+    ```
+  - **Windows (PowerShell):**
+    ```powershell
+    uv tool install "vpype[all]"
+    ```
+- A CLI-only version of *vpype* can be installed using the following command (no quoting needed since there are no square brackets):
   ```bash
-  pipx install "vpype[all]"
-  ```
-- A CLI-only version of *vpype* can be installed using the following command:
-  ```bash
-  pipx install vpype
+  uv tool install vpype
   ```
   This version does not include the [`show`](https://vpype.readthedocs.io/en/latest/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide6, and ModernGL).
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ TL;DR:
 - *vpype* is compatible with Python 3.11, 3.12, and 3.13.
 - *vpype* is published on the [Python Package Index](https://pypi.org) and can be installed with [`uv tool`](https://docs.astral.sh/uv/guides/tools/) (install `uv` itself by following the [official `uv` installation instructions](https://docs.astral.sh/uv/getting-started/installation/)).
 - `uv` will download a suitable managed Python interpreter automatically, so you do not need to install Python first.
-- The commands below pass `--python 3.13` explicitly. Without it, `uv` will pick Python 3.14, which currently fails because [ModernGL](https://pypi.org/project/moderngl/) (a viewer dependency) does not yet publish 3.14 wheels. Python 3.13 is the latest version for which all viewer dependencies ship pre-built wheels.
 - The package name to install is `vpype[all]`. Quoting rules depend on the shell:
   - **macOS / Linux (bash, zsh):**
     ```bash
@@ -210,7 +209,7 @@ TL;DR:
   ```bash
   uv tool install vpype
   ```
-  This version does not include the [`show`](https://vpype.readthedocs.io/en/latest/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide6, and ModernGL). Because none of the lagging-wheel dependencies are involved, the `--python 3.13` flag is not needed.
+  This version does not include the [`show`](https://vpype.readthedocs.io/en/latest/reference.html#show) command but does not require some of the dependencies which are more difficult or impossible to install on some platforms (such as matplotlib, PySide6, and ModernGL).
 
 
 ## Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,11 +24,11 @@ Download and install
 .. highlight:: bash
 
 *vpype* can be installed from the `Python Package Index <https://pypi.org>`_
-using pipx::
+using `uv <https://docs.astral.sh/uv/>`_::
 
-  $ pipx install "vpype[all]"
+  $ uv tool install "vpype[all]"
 
-Check the :ref:`installation instruction <install>` for step-by-step explanations.
+(On Windows ``cmd.exe``, omit the quotes.) Check the :ref:`installation instruction <install>` for step-by-step explanations, including how to install ``uv`` itself.
 
 Using this documentation
 ------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ using `uv <https://docs.astral.sh/uv/>`_::
 
   $ uv tool install --python 3.13 "vpype[all]"
 
-(On Windows ``cmd.exe``, omit the quotes. The ``--python 3.13`` flag is needed because one viewer dependency, ModernGL, does not yet publish wheels for Python 3.14.) Check the :ref:`installation instruction <install>` for step-by-step explanations, including how to install ``uv`` itself.
+(On Windows ``cmd.exe``, omit the quotes.) Check the :ref:`installation instruction <install>` for step-by-step explanations, including how to install ``uv`` itself.
 
 Using this documentation
 ------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,9 @@ Download and install
 *vpype* can be installed from the `Python Package Index <https://pypi.org>`_
 using `uv <https://docs.astral.sh/uv/>`_::
 
-  $ uv tool install "vpype[all]"
+  $ uv tool install --python 3.13 "vpype[all]"
 
-(On Windows ``cmd.exe``, omit the quotes.) Check the :ref:`installation instruction <install>` for step-by-step explanations, including how to install ``uv`` itself.
+(On Windows ``cmd.exe``, omit the quotes. The ``--python 3.13`` flag is needed because one viewer dependency, ModernGL, does not yet publish wheels for Python 3.14.) Check the :ref:`installation instruction <install>` for step-by-step explanations, including how to install ``uv`` itself.
 
 Using this documentation
 ------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,65 +9,77 @@ This page explain how to install *vpype* for end-users. If you intend to develop
 
 .. note::
 
-  The recommended Python version is 3.13. *vpype* is also compatible with Python 3.11 and 3.12.
+  *vpype* is compatible with Python 3.11, 3.12, and 3.13.
 
-.. warning::
-
-  *vpype* is not yet compatible with Python 3.13.
+The recommended way to install *vpype* is with `uv`_, a fast Python package and project manager that can also manage Python installations and install standalone tools (similar to ``pipx``). With ``uv tool install``, you do not need to install Python yourself: ``uv`` will download a suitable pre-built Python interpreter automatically and isolate *vpype* in its own environment.
 
 
-macOS
-=====
+Installing uv
+=============
+
+Follow the `official uv installation instructions <https://docs.astral.sh/uv/getting-started/installation/>`_ for your platform. The most common commands are reproduced below for convenience, but please refer to the official documentation for the most up-to-date information.
 
 .. highlight:: bash
 
+On macOS and Linux::
 
-Installing Python
------------------
+  curl -LsSf https://astral.sh/uv/install.sh | sh
 
-The official installer is the recommended way to install Python on your computer. It can be downloaded `here <https://www.python.org/downloads/>`__.
+.. highlight:: powershell
 
-.. caution::
+On Windows (PowerShell)::
 
-  When install Python, make sure to select version that is compatible with *vpype*. See the :doc:`top of this page <install>` for more information.
+  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 
+After installing ``uv``, restart your terminal and confirm it is available::
 
-You can  ensure that the installed Python interpreter is properly installed by running this command::
-
-  python3 --version
-
-It should produce an output similar to::
-
-  Python 3.13.2
-
-The version number should match the installer you used.
-
-Note that installing Python from `Homebrew <https://brew.sh>`__ or `MacPorts`_ is possible as well.
-
-
-Installing pipx
----------------
-
-`pipx`_ is a tool that allows you to install Python applications in isolated environments. It is the recommended way to install *vpype* on macOS. It can be installed with the following commands::
-
-  python3 -m pip install pipx
-  python3 -m pipx ensurepath
-
-After this, restart your terminal and ensure that pipx is properly installed by running this command::
-
-  pipx --version
-
-It should print out the current version of pipx without error::
-
-  1.2.0
+  uv --version
 
 
 Installing *vpype*
-------------------
+==================
 
-Once pipx is properly installed, you can install *vpype* with the following command::
+Once ``uv`` is installed, use ``uv tool install`` to install *vpype*. The package name is ``vpype[all]`` (the ``[all]`` extra pulls in the viewer dependencies: matplotlib, PySide6, and ModernGL).
 
-  pipx install "vpype[all]"
+.. caution::
+
+  In zsh and bash (the default shells on macOS and Linux), the square brackets in ``vpype[all]`` are interpreted as shell glob characters and **must be quoted**. On Windows ``cmd.exe`` they are not special, but on PowerShell they are — so quoting everywhere on Windows is the safer default.
+
+
+macOS and Linux (bash, zsh)
+---------------------------
+
+.. highlight:: bash
+
+::
+
+  uv tool install "vpype[all]"
+
+
+Windows (cmd.exe)
+-----------------
+
+.. highlight:: bat
+
+::
+
+  uv tool install vpype[all]
+
+
+Windows (PowerShell)
+--------------------
+
+.. highlight:: powershell
+
+::
+
+  uv tool install "vpype[all]"
+
+
+Verifying the installation
+==========================
+
+.. highlight:: bash
 
 *vpype* should now be installed and ready to use. You may check that it is fully functional by checking its version or displaying some random lines::
 
@@ -75,98 +87,44 @@ Once pipx is properly installed, you can install *vpype* with the following comm
   vpype random show
 
 
-Windows
-=======
+Picking a Python version
+========================
 
-.. highlight:: bat
+By default, ``uv tool install`` selects the most recent Python interpreter compatible with *vpype*'s ``requires-python`` constraint and downloads a managed, pre-built standalone Python build if needed. Because these managed builds match the platforms that most projects publish wheels for, you should generally not need to build any dependency from source.
 
+If you do run into a dependency that fails to build (for example because no wheel is available for the chosen Python version), you can pin a specific Python version with the ``--python`` flag. For example::
 
-Installing using pipx
----------------------
+  uv tool install --python 3.13 "vpype[all]"
 
-First, install Python. The official Python distribution for Windows can be `downloaded here <https://www.python.org/downloads/>`__ or installed from the `App Store <https://www.microsoft.com/en-us/p/python-310/9pjpw5ldxlz5>`_. When installing Python, make sure you enable adding Python to the path.
-
-.. caution::
-
-  When install Python, make sure to select version that is compatible with *vpype*. See the :doc:`top of this page <install>` for more information.
-
-Then, install pipx::
-
-  python -m pip install --user pipx
-  pipx ensurepath
-
-In the first command, replace ``python`` by ``python3`` if you installed Python from the App Store. The second command above ensures that both pipx and the software it will install are available the terminal. You may need to close and re-open the terminal for this to take effect.
-
-Finally, install *vpype*::
-
-  pipx install "vpype[all]"
-
-*vpype* should now be installed and ready to use. You may check that it is fully functional by checking its version and displaying some random lines::
-
-  vpype --version
-  vpype random show
-
-Linux
-=====
-
-.. highlight:: bash
-
-First, install `pipx`_ with your system's package manager. On Debian/Ubuntu flavored installation, this is typically done as follows::
-
-  sudo apt-get install pipx
-
-Then run the following command to ensure your path variable is properly set::
-
-  pipx ensurepath
-
-You may need to close and re-open the terminal window for this to take effect.
-
-Finally, install *vpype*::
-
-  pipx install "vpype[all]"
-
-*vpype* should now be installed and ready to use. You may check that it is fully functional by checking its version and displaying some random lines::
-
-  vpype --version
-  vpype random show
+Replace ``3.13`` with the version you want to target.
 
 
 Raspberry Pi
 ============
 
-Full installation including the viewer on the Raspberry Pi is no longer supported. Expert users may succeed with ``pipx install "vpype[all]"``. Also, the new viewer requires OpenGL 3.3, which the Raspberry Pi does not support. The classic viewer should work correctly::
+.. highlight:: bash
+
+Full installation including the viewer on the Raspberry Pi is no longer supported. Expert users may succeed with ``uv tool install "vpype[all]"``. Also, the new viewer requires OpenGL 3.3, which the Raspberry Pi does not support. The classic viewer should work correctly::
 
   vpype [...] show --classic
 
-Installing the CLI-only version described in the next section is easier and should be favored whenever possible. Here are the recommended steps to do so.
-
-Some packages and their dependencies are easier to install at the system level::
-
-  sudo apt-get install python3-shapely python3-numpy python3-scipy
-
-Then, install pipx::
-
-  sudo apt-get install pipx
-  pipx ensurepath
-
-Finally, install and run *vpype*::
-
-  pipx install vpype
-  vpype --version
+Installing the CLI-only version described in the next section is easier and should be favored whenever possible.
 
 
 CLI-only install
 ================
 
+.. highlight:: bash
+
 For special cases where the :ref:`cmd_show` is not needed and dependencies such as matplotlib, PySide6, or ModernGL are difficult to install, a CLI-only version of *vpype* can be installed using this command::
 
-  pipx install vpype
+  uv tool install vpype
 
-Note the missing ``[all]`` compared the instructions above.
+Note the missing ``[all]`` compared the instructions above. Since there are no square brackets, no quoting is required on any shell.
 
 
 .. _pip: https://pip.pypa.io/en/stable
-.. _pipx: https://pypa.github.io/pipx
+.. _uv: https://docs.astral.sh/uv/
 .. _MacPorts: https://www.macports.org
 .. _PyPI: https://pypi.org
 .. _venv: https://docs.python.org/3/library/venv.html

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,10 +45,6 @@ Once ``uv`` is installed, use ``uv tool install`` to install *vpype*. The packag
 
   In zsh and bash (the default shells on macOS and Linux), the square brackets in ``vpype[all]`` are interpreted as shell glob characters and **must be quoted**. On Windows ``cmd.exe`` they are not special, but on PowerShell they are — so quoting everywhere on Windows is the safer default.
 
-.. important::
-
-  The commands below pass ``--python 3.13`` explicitly. Without it, ``uv`` will pick the newest Python interpreter available, and at least one of the viewer dependencies (ModernGL) does not yet publish wheels for Python 3.14, which causes the install to fail trying to build from source. Python 3.13 is the latest version for which all viewer dependencies ship pre-built wheels.
-
 
 macOS and Linux (bash, zsh)
 ---------------------------
@@ -89,16 +85,6 @@ Verifying the installation
 
   vpype --version
   vpype random show
-
-
-Why ``--python 3.13``?
-======================
-
-By default, ``uv tool install`` selects the most recent Python interpreter compatible with *vpype*'s ``requires-python`` constraint and downloads a managed, pre-built standalone Python build if needed. As long as every dependency publishes wheels for that interpreter, the install completes without any compilation.
-
-The problem is that wheel coverage for the very latest Python release tends to lag. At the time of writing, ModernGL (a viewer dependency) does not yet ship wheels for Python 3.14, so letting ``uv`` pick 3.14 results in a build-from-source attempt that fails on most machines. Pinning ``--python 3.13`` sidesteps this by targeting the latest interpreter for which all viewer dependencies have pre-built wheels.
-
-Once ModernGL (and any other lagging dependency) publishes 3.14 wheels, you can drop the flag — or bump it to a newer version — and ``uv`` will resolve normally.
 
 
 Raspberry Pi

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,6 +45,10 @@ Once ``uv`` is installed, use ``uv tool install`` to install *vpype*. The packag
 
   In zsh and bash (the default shells on macOS and Linux), the square brackets in ``vpype[all]`` are interpreted as shell glob characters and **must be quoted**. On Windows ``cmd.exe`` they are not special, but on PowerShell they are — so quoting everywhere on Windows is the safer default.
 
+.. important::
+
+  The commands below pass ``--python 3.13`` explicitly. Without it, ``uv`` will pick the newest Python interpreter available, and at least one of the viewer dependencies (ModernGL) does not yet publish wheels for Python 3.14, which causes the install to fail trying to build from source. Python 3.13 is the latest version for which all viewer dependencies ship pre-built wheels.
+
 
 macOS and Linux (bash, zsh)
 ---------------------------
@@ -53,7 +57,7 @@ macOS and Linux (bash, zsh)
 
 ::
 
-  uv tool install "vpype[all]"
+  uv tool install --python 3.13 "vpype[all]"
 
 
 Windows (cmd.exe)
@@ -63,7 +67,7 @@ Windows (cmd.exe)
 
 ::
 
-  uv tool install vpype[all]
+  uv tool install --python 3.13 vpype[all]
 
 
 Windows (PowerShell)
@@ -73,7 +77,7 @@ Windows (PowerShell)
 
 ::
 
-  uv tool install "vpype[all]"
+  uv tool install --python 3.13 "vpype[all]"
 
 
 Verifying the installation
@@ -87,16 +91,14 @@ Verifying the installation
   vpype random show
 
 
-Picking a Python version
-========================
+Why ``--python 3.13``?
+======================
 
-By default, ``uv tool install`` selects the most recent Python interpreter compatible with *vpype*'s ``requires-python`` constraint and downloads a managed, pre-built standalone Python build if needed. Because these managed builds match the platforms that most projects publish wheels for, you should generally not need to build any dependency from source.
+By default, ``uv tool install`` selects the most recent Python interpreter compatible with *vpype*'s ``requires-python`` constraint and downloads a managed, pre-built standalone Python build if needed. As long as every dependency publishes wheels for that interpreter, the install completes without any compilation.
 
-If you do run into a dependency that fails to build (for example because no wheel is available for the chosen Python version), you can pin a specific Python version with the ``--python`` flag. For example::
+The problem is that wheel coverage for the very latest Python release tends to lag. At the time of writing, ModernGL (a viewer dependency) does not yet ship wheels for Python 3.14, so letting ``uv`` pick 3.14 results in a build-from-source attempt that fails on most machines. Pinning ``--python 3.13`` sidesteps this by targeting the latest interpreter for which all viewer dependencies have pre-built wheels.
 
-  uv tool install --python 3.13 "vpype[all]"
-
-Replace ``3.13`` with the version you want to target.
+Once ModernGL (and any other lagging dependency) publishes 3.14 wheels, you can drop the flag — or bump it to a newer version — and ``uv`` will resolve normally.
 
 
 Raspberry Pi
@@ -104,7 +106,7 @@ Raspberry Pi
 
 .. highlight:: bash
 
-Full installation including the viewer on the Raspberry Pi is no longer supported. Expert users may succeed with ``uv tool install "vpype[all]"``. Also, the new viewer requires OpenGL 3.3, which the Raspberry Pi does not support. The classic viewer should work correctly::
+Full installation including the viewer on the Raspberry Pi is no longer supported. Expert users may succeed with ``uv tool install --python 3.13 "vpype[all]"``. Also, the new viewer requires OpenGL 3.3, which the Raspberry Pi does not support. The classic viewer should work correctly::
 
   vpype [...] show --classic
 


### PR DESCRIPTION
## Summary

Update the README, the docs landing page, and the installation guide to recommend [`uv tool install`](https://docs.astral.sh/uv/guides/tools/) as the primary install method, with a link to the [official uv installation instructions](https://docs.astral.sh/uv/getting-started/installation/) for setting up `uv` itself.

### Shell-specific examples

`vpype[all]` quoting rules differ by shell, so the docs now show three copy-pastable commands:

- **macOS / Linux (bash, zsh):** `uv tool install "vpype[all]"` — square brackets are glob characters in bash/zsh and must be quoted.
- **Windows (`cmd.exe`):** `uv tool install vpype[all]` — `cmd.exe` does not treat `[` / `]` specially.
- **Windows (PowerShell):** `uv tool install "vpype[all]"` — PowerShell does treat `[` / `]` specially, so quoting is required.

The CLI-only command (`uv tool install vpype`) has no extras, so no quoting is ever needed.

### Other doc fixes

- Remove the contradictory "not yet compatible with Python 3.13" warning in `install.rst` — the project's `requires-python = ">=3.11, <3.14"` already supports 3.13.
- Add a "Picking a Python version" section explaining that `uv tool install` picks the latest compatible interpreter and downloads a managed standalone Python build by default (so dependencies like ModernGL find pre-built wheels), and that `--python 3.13` can pin a specific version if a wheel is missing for the default choice.
- Drop the per-OS "Installing Python" sections since `uv` handles that itself.

The developer-focused `contributing.rst` still mentions Poetry/pipx for the dev workflow and is intentionally left untouched.

## Test plan

- [ ] Build the docs locally and verify `install.rst` and `index.rst` render correctly.
- [ ] Confirm `uv tool install "vpype[all]"` works on macOS/Linux from a clean machine.
- [ ] Confirm `uv tool install vpype[all]` works in Windows `cmd.exe` and `uv tool install "vpype[all]"` works in PowerShell.
- [ ] Confirm `uv tool install vpype` (CLI-only) works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVM9eZSVZBj7FMAsiY4RhA)_