### PR TITLE
Fix layers being merged on read when SVG groups share the same inkscape:label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* ...
+* Fixed layers being merged when reading a SVG whose groups share the same `inkscape:label` (e.g. as produced by `splitdist` followed by `write`); the label is now only used to determine layer IDs when it yields a distinct ID for every group, otherwise the `id` attribute is used instead
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Release date: UNRELEASED
 
 ### Bug fixes
 
-* Fixed layers being merged when reading a SVG whose groups share the same `inkscape:label` (e.g. as produced by `splitdist` followed by `write`); the label is now only used to determine layer IDs when it yields a distinct ID for every group, otherwise the `id` attribute is used instead
+* Fixed layers being merged when reading a SVG whose groups share the same `inkscape:label` (e.g. as produced by `splitdist` followed by `write`); the `inkscape:label` attribute is now ignored when it would assign the same layer ID to two groups, in which case the `id` attribute (or, lacking digits, the group's appearing order) is used instead (#855)
 
 ### Other changes
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -651,3 +651,54 @@ def test_read_layer_id_from_svg(attr, exp):
     doc = vp.read_multilayer_svg(io.StringIO(svg), 0.1)
     assert doc.layers.keys() == {exp}
     assert len(doc.layers[exp]) == 1
+
+
+def test_read_layer_id_colliding_labels_fall_back_to_id():
+    # Several groups sharing the same `inkscape:label` (e.g. as produced by the `splitdist`
+    # command) must not be merged into a single layer. As the label does not yield a distinct
+    # ID per group, the (distinct) `id` attribute is used instead.
+    svg = """<?xml version="1.0"?><svg width="500" height="300"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
+        <g inkscape:label="2" id="layer2">
+                <line x1="0" y1="0" x2="10" y2="10" />
+        </g>
+        <g inkscape:label="2" id="layer4">
+                <line x1="0" y1="0" x2="20" y2="20" />
+        </g>
+        <g inkscape:label="2" id="layer5">
+                <line x1="0" y1="0" x2="30" y2="30" />
+        </g>
+    </svg>"""
+
+    doc = vp.read_multilayer_svg(io.StringIO(svg), 0.1)
+    assert doc.layers.keys() == {2, 4, 5}
+
+
+def test_read_layer_id_distinct_labels_take_priority():
+    # When the labels yield a distinct ID for every group, they take priority over the `id`
+    # attribute (here deliberately off-by-one, as Inkscape produces).
+    svg = """<?xml version="1.0"?><svg width="500" height="300"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
+        <g inkscape:label="1" id="layer0">
+                <line x1="0" y1="0" x2="10" y2="10" />
+        </g>
+        <g inkscape:label="2" id="layer1">
+                <line x1="0" y1="0" x2="20" y2="20" />
+        </g>
+    </svg>"""
+
+    doc = vp.read_multilayer_svg(io.StringIO(svg), 0.1)
+    assert doc.layers.keys() == {1, 2}
+
+
+def test_splitdist_write_read_roundtrip(tmp_path):
+    # Regression test: `splitdist` spreads a layer over several new layers that all inherit its
+    # name. When that name contains a digit (e.g. "2", as obtained by reading a layer labelled
+    # "2"), writing and reading back must preserve the layers as distinct rather than merging
+    # them via their (colliding) `inkscape:label`.
+    path = str(tmp_path / "split.svg")
+    before = vpype_cli.execute(f"random -n 100 -a 10cm 10cm name 2 splitdist 1cm write {path}")
+    assert len(before.layers) > 1
+
+    after = vpype_cli.execute(f"read {path}")
+    assert len(after.layers) == len(before.layers)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -653,42 +653,113 @@ def test_read_layer_id_from_svg(attr, exp):
     assert len(doc.layers[exp]) == 1
 
 
-def test_read_layer_id_colliding_labels_fall_back_to_id():
-    # Several groups sharing the same `inkscape:label` (e.g. as produced by the `splitdist`
-    # command) must not be merged into a single layer. As the label does not yield a distinct
-    # ID per group, the (distinct) `id` attribute is used instead.
+def _multi_group_svg(attrs: list[str]) -> str:
+    """Build a SVG with one single-line group per item in *attrs*."""
+    groups = "\n".join(
+        f'<g {attr}><line x1="0" y1="0" x2="{10 + 10 * i}" y2="10" /></g>'
+        for i, attr in enumerate(attrs)
+    )
+    return f"""<?xml version="1.0"?><svg width="500" height="300"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">{groups}</svg>"""
+
+
+@pytest.mark.parametrize(
+    ("attrs", "exp"),
+    [
+        # distinct labels take priority over the `id` attribute (here deliberately off-by-one,
+        # as Inkscape numbers it)
+        (['inkscape:label="1" id="layer0"', 'inkscape:label="2" id="layer1"'], {1, 2}),
+        # groups sharing the same label (e.g. as produced by the `splitdist` command) must not
+        # be merged: the label is ignored and the (distinct) `id` attribute used instead
+        (
+            [
+                'inkscape:label="2" id="layer2"',
+                'inkscape:label="2" id="layer4"',
+                'inkscape:label="2" id="layer5"',
+            ],
+            {2, 4, 5},
+        ),
+        # ditto, for labels colliding only because 0 is remapped to 1
+        (['inkscape:label="0" id="layer7"', 'inkscape:label="1" id="layer9"'], {7, 9}),
+        # a group whose label has no digits falls back on its own `id` attribute, without
+        # discarding the (non-colliding) labels of the other groups
+        (['inkscape:label="Pen 3" id="g5"', 'inkscape:label="hello" id="g8"'], {3, 8}),
+        # ditto for a group with no label at all, as found in Inkscape files whose top-level
+        # groups are not all layers
+        (
+            [
+                'inkscape:groupmode="layer" inkscape:label="Pen 1" id="layer1"',
+                'inkscape:groupmode="layer" inkscape:label="Pen 3" id="layer2"',
+                'inkscape:groupmode="layer" inkscape:label="Pen 5" id="layer3"',
+                'id="g100"',
+            ],
+            {1, 3, 5, 100},
+        ),
+        # when neither the labels nor the `id`s are distinct, the appearing order is used
+        (['inkscape:label="a" id="layer2"', 'inkscape:label="a" id="layer2"'], {1, 2}),
+        # the `id` attribute is used even when it is not of the `layer{N}` form written by
+        # vpype, so colliding labels may yield surprising (though distinct) layer IDs
+        (
+            ['inkscape:label="Pen 2" id="layer1"', 'inkscape:label="Pen 2" id="g8472"'],
+            {1, 8472},
+        ),
+        # lacking digits altogether, the appearing order is used
+        (["", 'id="foo"'], {1, 2}),
+    ],
+)
+def test_read_layer_id_multiple_groups(attrs, exp):
+    doc = vp.read_multilayer_svg(io.StringIO(_multi_group_svg(attrs)), 0.1)
+
+    assert doc.layers.keys() == exp
+    assert all(len(lc) == 1 for lc in doc.layers.values())
+
+
+def test_read_layer_id_colliding_labels_preserve_layer_names():
+    # Falling back on the `id` attribute must not affect the layer names, which are still taken
+    # from the `inkscape:label` attribute.
+    doc = vp.read_multilayer_svg(
+        io.StringIO(
+            _multi_group_svg(
+                ['inkscape:label="2" id="layer4"', 'inkscape:label="2" id="layer5"']
+            )
+        ),
+        0.1,
+    )
+
+    assert {lid: lc.property(vp.METADATA_FIELD_NAME) for lid, lc in doc.layers.items()} == {
+        4: "2",
+        5: "2",
+    }
+
+
+def test_read_layer_id_empty_group_consumes_appearing_order():
+    # An empty group is not imported, but still counts towards the appearing order used as
+    # last-resort layer ID.
     svg = """<?xml version="1.0"?><svg width="500" height="300"
     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
-        <g inkscape:label="2" id="layer2">
-                <line x1="0" y1="0" x2="10" y2="10" />
-        </g>
-        <g inkscape:label="2" id="layer4">
-                <line x1="0" y1="0" x2="20" y2="20" />
-        </g>
-        <g inkscape:label="2" id="layer5">
-                <line x1="0" y1="0" x2="30" y2="30" />
-        </g>
+        <g id="a"></g>
+        <g id="b"><line x1="0" y1="0" x2="10" y2="10" /></g>
+        <g id="c"><line x1="0" y1="0" x2="20" y2="20" /></g>
     </svg>"""
 
     doc = vp.read_multilayer_svg(io.StringIO(svg), 0.1)
-    assert doc.layers.keys() == {2, 4, 5}
+    assert doc.layers.keys() == {2, 3}
 
 
-def test_read_layer_id_distinct_labels_take_priority():
-    # When the labels yield a distinct ID for every group, they take priority over the `id`
-    # attribute (here deliberately off-by-one, as Inkscape produces).
+def test_read_layer_id_colliding_labels_merge_with_top_level_paths():
+    # Top-level paths are imported in layer 1. A group falling back on an `id` attribute which
+    # resolves to layer 1 must be merged into it, as it would be with any other ID source.
     svg = """<?xml version="1.0"?><svg width="500" height="300"
     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
-        <g inkscape:label="1" id="layer0">
-                <line x1="0" y1="0" x2="10" y2="10" />
-        </g>
-        <g inkscape:label="2" id="layer1">
-                <line x1="0" y1="0" x2="20" y2="20" />
-        </g>
+        <line x1="0" y1="0" x2="5" y2="5" />
+        <g inkscape:label="2" id="layer1"><line x1="0" y1="0" x2="10" y2="10" /></g>
+        <g inkscape:label="2" id="layer3"><line x1="0" y1="0" x2="20" y2="20" /></g>
     </svg>"""
 
     doc = vp.read_multilayer_svg(io.StringIO(svg), 0.1)
-    assert doc.layers.keys() == {1, 2}
+    assert doc.layers.keys() == {1, 3}
+    assert len(doc.layers[1]) == 2
+    assert len(doc.layers[3]) == 1
 
 
 def test_splitdist_write_read_roundtrip(tmp_path):
@@ -697,8 +768,14 @@ def test_splitdist_write_read_roundtrip(tmp_path):
     # "2"), writing and reading back must preserve the layers as distinct rather than merging
     # them via their (colliding) `inkscape:label`.
     path = str(tmp_path / "split.svg")
-    before = vpype_cli.execute(f"random -n 100 -a 10cm 10cm name 2 splitdist 1cm write {path}")
+    before = vpype_cli.execute(
+        f"random -n 100 -a 10cm 10cm name 2 splitdist 1cm write {path}", global_opt="--seed 0"
+    )
     assert len(before.layers) > 1
 
     after = vpype_cli.execute(f"read {path}")
     assert len(after.layers) == len(before.layers)
+    assert sum(len(lc) for lc in after.layers.values()) == sum(
+        len(lc) for lc in before.layers.values()
+    )
+    assert after.length() == pytest.approx(before.length())

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -459,8 +459,11 @@ def read_multilayer_svg(
 
     Groups are matched to layer ID according their `inkscape:label` attribute, their `id`
     attribute or their appearing order, in that order of priority. The first contiguous group
-    of digits in the label is used as layer ID. Lacking numeric characters, the appearing order
-    is used. If the label is 0, it is changed to 1.
+    of digits in the corresponding attribute is used as layer ID (if it is 0, it is changed to
+    1). The `inkscape:label` attribute is only used when it yields a distinct ID for every
+    group, so that groups sharing the same label (e.g. as produced by the `splitdist` command)
+    are not inadvertently merged into a single layer; the `id` attribute is used instead in
+    that case. Lacking numeric characters altogether, the appearing order is used.
 
     All curved geometries are chopped in segments no longer than the value of *quantization*.
     Optionally, the geometries are simplified using Shapely, using the value of *quantization*
@@ -503,20 +506,19 @@ def read_multilayer_svg(
             if isinstance(elem, svgelements.Group):
                 yield elem
 
-    for i, g in enumerate(_find_groups(svg)):
+    def _parse_lid(text: str | None) -> int | None:
+        """Extract a layer ID from a label or id attribute, or None if it has no digits."""
+        digits = _extract_digit_group(text or "")
+        if digits is None:
+            return None
+        lid = int(digits)
+        return 1 if lid == 0 else lid
+
+    # gather all non-empty groups along with their candidate layer IDs
+    groups = []  # list of (layer_name, label_lid, id_lid, lc)
+    for g in _find_groups(svg):
         # noinspection HttpUrlsUsage
         layer_name = g.values.get("{http://www.inkscape.org/namespaces/inkscape}label", None)
-
-        # compute a decent layer ID
-        lid_str = _extract_digit_group(layer_name or "")
-        if not lid_str:
-            lid_str = _extract_digit_group(g.values.get("id") or "")
-        if lid_str:
-            lid = int(lid_str)
-            if lid == 0:
-                lid = 1
-        else:
-            lid = i + 1
 
         paths, metadata = _extract_paths(g, True)
         lc = _flattened_paths_to_line_collection(
@@ -524,16 +526,38 @@ def read_multilayer_svg(
         )
 
         if not lc.is_empty():
-            # deal with the case of layer 1, which may already be initialized with top-level
-            # paths
-            if lid in document.layers:
-                metadata = _intersect_dict(document.layers[lid].metadata, lc.metadata)
-            else:
-                metadata = lc.metadata
+            groups.append(
+                (layer_name, _parse_lid(layer_name), _parse_lid(g.values.get("id")), lc)
+            )
 
-            document.add(lc, lid)
-            document.layers[lid].metadata = metadata
-            document.layers[lid].set_property(METADATA_FIELD_NAME, layer_name)
+    # Compute the layer ID for each group. The `inkscape:label` is the preferred source as it
+    # reflects the user-visible layer name (e.g. as set in Inkscape). However, using it would
+    # silently merge unrelated layers should two of them yield the same ID (for example several
+    # layers sharing the same name, as produced by the `splitdist` command). It is therefore
+    # only used when it provides a distinct ID for every group. The `id` attribute (which vpype
+    # writes as `layer{N}`) and, finally, the group order are used as fallbacks.
+    def _all_distinct(ids: list[int | None]) -> bool:
+        return None not in ids and len(set(ids)) == len(ids)
+
+    label_ids = [label_lid for _, label_lid, _, _ in groups]
+    id_ids = [id_lid for _, _, id_lid, _ in groups]
+    if _all_distinct(label_ids):
+        layer_ids: list[int] = cast(list[int], label_ids)
+    elif _all_distinct(id_ids):
+        layer_ids = cast(list[int], id_ids)
+    else:
+        layer_ids = list(range(1, len(groups) + 1))
+
+    for (layer_name, _, _, lc), lid in zip(groups, layer_ids):
+        # deal with the case of layer 1, which may already be initialized with top-level paths
+        if lid in document.layers:
+            metadata = _intersect_dict(document.layers[lid].metadata, lc.metadata)
+        else:
+            metadata = lc.metadata
+
+        document.add(lc, lid)
+        document.layers[lid].metadata = metadata
+        document.layers[lid].set_property(METADATA_FIELD_NAME, layer_name)
 
     document.page_size = (svg.width, svg.height)
 

--- a/vpype/io.py
+++ b/vpype/io.py
@@ -459,11 +459,14 @@ def read_multilayer_svg(
 
     Groups are matched to layer ID according their `inkscape:label` attribute, their `id`
     attribute or their appearing order, in that order of priority. The first contiguous group
-    of digits in the corresponding attribute is used as layer ID (if it is 0, it is changed to
-    1). The `inkscape:label` attribute is only used when it yields a distinct ID for every
-    group, so that groups sharing the same label (e.g. as produced by the `splitdist` command)
-    are not inadvertently merged into a single layer; the `id` attribute is used instead in
-    that case. Lacking numeric characters altogether, the appearing order is used.
+    of digits in the corresponding attribute is used as layer ID. Lacking numeric characters,
+    the appearing order is used. If the label is 0, it is changed to 1.
+
+    Since two groups may share the same `inkscape:label` (this is the case, for example, of the
+    layers created by the `splitdist` command, which all inherit the source layer's name),
+    relying on it could silently merge unrelated layers. The `inkscape:label` attribute is
+    therefore ignored for the entire document whenever it would assign the same ID to two
+    groups. Should the IDs still not be distinct, the appearing order is used for every group.
 
     All curved geometries are chopped in segments no longer than the value of *quantization*.
     Optionally, the geometries are simplified using Shapely, using the value of *quantization*
@@ -514,9 +517,17 @@ def read_multilayer_svg(
         lid = int(digits)
         return 1 if lid == 0 else lid
 
-    # gather all non-empty groups along with their candidate layer IDs
-    groups = []  # list of (layer_name, label_lid, id_lid, lc)
-    for g in _find_groups(svg):
+    @dataclasses.dataclass(frozen=True)
+    class _GroupDesc:
+        layer_name: str | None
+        label_lid: int | None  # layer ID candidate from the `inkscape:label` attribute
+        id_lid: int | None  # layer ID candidate from the `id` attribute
+        order_lid: int  # layer ID candidate from the group's appearing order
+        lc: LineCollection
+
+    # gather the non-empty groups, along with their layer ID candidates
+    groups: list[_GroupDesc] = []
+    for i, g in enumerate(_find_groups(svg)):
         # noinspection HttpUrlsUsage
         layer_name = g.values.get("{http://www.inkscape.org/namespaces/inkscape}label", None)
 
@@ -527,37 +538,50 @@ def read_multilayer_svg(
 
         if not lc.is_empty():
             groups.append(
-                (layer_name, _parse_lid(layer_name), _parse_lid(g.values.get("id")), lc)
+                _GroupDesc(
+                    layer_name=layer_name,
+                    label_lid=_parse_lid(layer_name),
+                    id_lid=_parse_lid(g.values.get("id")),
+                    order_lid=i + 1,
+                    lc=lc,
+                )
             )
 
-    # Compute the layer ID for each group. The `inkscape:label` is the preferred source as it
-    # reflects the user-visible layer name (e.g. as set in Inkscape). However, using it would
-    # silently merge unrelated layers should two of them yield the same ID (for example several
-    # layers sharing the same name, as produced by the `splitdist` command). It is therefore
-    # only used when it provides a distinct ID for every group. The `id` attribute (which vpype
-    # writes as `layer{N}`) and, finally, the group order are used as fallbacks.
-    def _all_distinct(ids: list[int | None]) -> bool:
-        return None not in ids and len(set(ids)) == len(ids)
+    def _assign_layer_ids(use_labels: bool) -> list[int] | None:
+        """Assign a layer ID to every group, or None if the result isn't distinct."""
+        layer_ids = []
+        for group in groups:
+            candidates = (
+                group.label_lid if use_labels else None,
+                group.id_lid,
+                group.order_lid,  # never None, so a candidate is always found
+            )
+            layer_ids.append(next(lid for lid in candidates if lid is not None))
+        return layer_ids if len(set(layer_ids)) == len(layer_ids) else None
 
-    label_ids = [label_lid for _, label_lid, _, _ in groups]
-    id_ids = [id_lid for _, _, id_lid, _ in groups]
-    if _all_distinct(label_ids):
-        layer_ids: list[int] = cast(list[int], label_ids)
-    elif _all_distinct(id_ids):
-        layer_ids = cast(list[int], id_ids)
-    else:
-        layer_ids = list(range(1, len(groups) + 1))
+    # The `inkscape:label` attribute is the preferred layer ID source, as it reflects the
+    # user-visible layer name (e.g. as set in Inkscape). Since several groups may share the
+    # same label, using it may however assign the same ID to unrelated groups and thus
+    # silently merge them. In such a case, the label is skipped for the whole document (rather
+    # than for the colliding groups only, which would renumber layers depending on unrelated
+    # ones) and the `id` attribute is used instead. The appearing order is the last-resort
+    # fallback.
+    layer_ids = _assign_layer_ids(use_labels=True)
+    if layer_ids is None:
+        layer_ids = _assign_layer_ids(use_labels=False)
+    if layer_ids is None:
+        layer_ids = [group.order_lid for group in groups]
 
-    for (layer_name, _, _, lc), lid in zip(groups, layer_ids):
+    for group, lid in zip(groups, layer_ids, strict=True):
         # deal with the case of layer 1, which may already be initialized with top-level paths
         if lid in document.layers:
-            metadata = _intersect_dict(document.layers[lid].metadata, lc.metadata)
+            metadata = _intersect_dict(document.layers[lid].metadata, group.lc.metadata)
         else:
-            metadata = lc.metadata
+            metadata = group.lc.metadata
 
-        document.add(lc, lid)
+        document.add(group.lc, lid)
         document.layers[lid].metadata = metadata
-        document.layers[lid].set_property(METADATA_FIELD_NAME, layer_name)
+        document.layers[lid].set_property(METADATA_FIELD_NAME, group.layer_name)
 
     document.page_size = (svg.width, svg.height)
 


### PR DESCRIPTION
## Problem

`vpype read input.svg splitdist -l 2 N write out.svg` followed by `read out.svg` collapsed the split layers back together. For example, with a 3-layer input where layer 2 is split into 4 parts (6 layers in memory), re-reading the written SVG yielded only 3 layers, silently merging the four chunks of layer 2 back into one (62+79+92+30 → 263 paths).

The bug was on the **read** side, not write. `read_multilayer_svg` derived each layer's ID from the first digit group of its `inkscape:label`, taking priority over the always-unique `id="layer{N}"`. `splitdist` stamps the source layer's name onto every overflow layer, so the chunks were all written with `inkscape:label="2"` and collapsed to a single layer on read. The same footgun hit any document with two layers sharing a digit-containing name (`pen2`, `layer2`, …), not just `splitdist` output.

## Fix

The per-group priority chain (`inkscape:label` → `id` → appearing order) is left as-is. What's added is a **collision check on the resulting assignment**: if two groups end up with the same layer ID, the IDs are recomputed with `inkscape:label` ignored, letting the `id` attribute (which vpype writes as `layer{N}`) take over. Should the IDs still collide, the appearing order is used for every group.

The label is skipped for the whole document rather than for the colliding groups only, so that a layer's ID never depends on whether some *unrelated* layer happens to share its name.

This:
- makes the write→read round-trip lossless for `splitdist` output and any duplicate digit-names;
- preserves the Inkscape "rename a layer to a number" semantics for the common distinct case (verified against the existing `multilayer_named_layers.svg` fixture, whose `id`s are off-by-one — labels correctly still win there);
- leaves every non-colliding document reading exactly as before, including mixed ones where only some groups carry a numeric label: each group still falls back to its own `id`, without the other groups' labels being discarded.

## Tests

`test_read_layer_id_multiple_groups` is a new parametrized table covering multi-group ID resolution, in the style of the existing `test_read_layer_id_from_svg`: distinct labels winning over `id`, labels colliding both directly and through the 0→1 remapping, a group whose label lacks digits falling back on its own `id`, Inkscape files whose top-level groups aren't all layers, both sources colliding, and no digits anywhere.

Alongside it:
- `test_read_layer_id_colliding_labels_preserve_layer_names` — falling back on `id` doesn't affect the layer names, still taken from `inkscape:label`;
- `test_read_layer_id_empty_group_consumes_appearing_order` — empty groups are not imported but still count towards the appearing order;
- `test_read_layer_id_colliding_labels_merge_with_top_level_paths` — a group resolving to layer 1 is still merged with the top-level paths;
- `test_splitdist_write_read_roundtrip` — full `splitdist` → `write` → `read` round-trip, seeded (`--seed 0`) and asserting total path count and length in addition to the layer count.

7 of the 12 fail on `master`; the others pin behaviour that must not change. `test_files.py` + `test_commands.py` pass (1033 passed, 67 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
